### PR TITLE
feature: 농장 공지에 댓글을 달고 조회하는 기능 추가

### DIFF
--- a/backend/member/src/main/java/org/samtuap/inong/domain/member/api/MemberController.java
+++ b/backend/member/src/main/java/org/samtuap/inong/domain/member/api/MemberController.java
@@ -1,14 +1,31 @@
 package org.samtuap.inong.domain.member.api;
 
+import lombok.RequiredArgsConstructor;
+import org.samtuap.inong.domain.member.dto.MemberDetailResponse;
+import org.samtuap.inong.domain.member.service.MemberService;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequestMapping("/member")
 @RestController
+@RequiredArgsConstructor
 public class MemberController {
+
+    private final MemberService memberService;
+
     @GetMapping
     public String testApi() {
         return "hello world!!!";
+    }
+
+    /**
+     * id로 회원 찾아오기 => product 모듈에서 feignclient로 찾아올 수 있도록 추가
+     */
+    @GetMapping("/{id}")
+    public MemberDetailResponse findMember(@PathVariable("id") Long id) {
+
+        return memberService.findMember(id);
     }
 }

--- a/backend/member/src/main/java/org/samtuap/inong/domain/member/dto/MemberDetailResponse.java
+++ b/backend/member/src/main/java/org/samtuap/inong/domain/member/dto/MemberDetailResponse.java
@@ -1,0 +1,27 @@
+package org.samtuap.inong.domain.member.dto;
+
+import lombok.Builder;
+import org.samtuap.inong.domain.member.entity.Member;
+
+@Builder
+public record MemberDetailResponse(
+        Long id,
+        String name,
+        String email,
+        String phone,
+        String address,
+        String addressDetail,
+        String zipcode
+) {
+    public static MemberDetailResponse from(Member member) {
+        return MemberDetailResponse.builder()
+                .id(member.getId())
+                .name(member.getName())
+                .email(member.getEmail())
+                .phone(member.getPhone())
+                .address(member.getAddress())
+                .addressDetail(member.getAddressDetail())
+                .zipcode(member.getZipcode())
+                .build();
+    }
+}

--- a/backend/member/src/main/java/org/samtuap/inong/domain/member/entity/Member.java
+++ b/backend/member/src/main/java/org/samtuap/inong/domain/member/entity/Member.java
@@ -4,8 +4,8 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 import org.samtuap.inong.domain.common.BaseEntity;
@@ -13,6 +13,7 @@ import org.samtuap.inong.domain.common.BaseEntity;
 @Entity
 @SQLDelete(sql = "UPDATE member SET deleted_at = now() WHERE id = ?")
 @SQLRestriction("deleted_at is NULL")
+@Getter
 public class Member extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/member/src/main/java/org/samtuap/inong/domain/member/service/MemberService.java
+++ b/backend/member/src/main/java/org/samtuap/inong/domain/member/service/MemberService.java
@@ -1,7 +1,26 @@
 package org.samtuap.inong.domain.member.service;
 
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.samtuap.inong.domain.member.dto.MemberDetailResponse;
+import org.samtuap.inong.domain.member.entity.Member;
+import org.samtuap.inong.domain.member.repository.MemberRepository;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    /**
+     * id로 회원 찾아오기
+     */
+    public MemberDetailResponse findMember(Long id) {
+
+        Member member = memberRepository.findById(id).orElseThrow(
+                () -> new EntityNotFoundException("해당 id의 회원이 존재하지 않습니다.")
+        );
+        return MemberDetailResponse.from(member);
+    }
 }

--- a/backend/product/build.gradle
+++ b/backend/product/build.gradle
@@ -32,6 +32,9 @@ dependencies {
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 	implementation 'org.springframework.kafka:spring-kafka'
+
+	// feignclient
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 }
 
 tasks.named('test') {

--- a/backend/product/src/main/java/org/samtuap/inong/config/FeignConfig.java
+++ b/backend/product/src/main/java/org/samtuap/inong/config/FeignConfig.java
@@ -1,0 +1,9 @@
+package org.samtuap.inong.config;
+
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableFeignClients(basePackages = "org.samtuap.inong.domain.farmNotice.service")
+public class FeignConfig {
+}

--- a/backend/product/src/main/java/org/samtuap/inong/domain/farmNotice/api/FarmNoticeController.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/farmNotice/api/FarmNoticeController.java
@@ -2,6 +2,7 @@ package org.samtuap.inong.domain.farmNotice.api;
 
 import lombok.RequiredArgsConstructor;
 import org.samtuap.inong.domain.farmNotice.dto.CommentCreateRequest;
+import org.samtuap.inong.domain.farmNotice.dto.CommentListResponse;
 import org.samtuap.inong.domain.farmNotice.dto.NoticeDetailResponse;
 import org.samtuap.inong.domain.farmNotice.dto.NoticeListResponse;
 import org.samtuap.inong.domain.farmNotice.service.FarmNoticeService;
@@ -46,5 +47,15 @@ public class FarmNoticeController {
                               @RequestBody CommentCreateRequest dto) {
 
         farmNoticeService.commentCreate(farmId, noticeId, memberId, dto);
+    }
+
+    /**
+     * 공지에 달린 댓글 조회
+     */
+    @GetMapping("/{farm_id}/notice/{notice_id}/comment")
+    public List<CommentListResponse> commentList(@PathVariable("farm_id") Long farmId,
+                                                 @PathVariable("notice_id") Long noticeId) {
+
+        return farmNoticeService.commentList(farmId, noticeId);
     }
 }

--- a/backend/product/src/main/java/org/samtuap/inong/domain/farmNotice/api/FarmNoticeController.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/farmNotice/api/FarmNoticeController.java
@@ -1,13 +1,11 @@
 package org.samtuap.inong.domain.farmNotice.api;
 
 import lombok.RequiredArgsConstructor;
+import org.samtuap.inong.domain.farmNotice.dto.CommentCreateRequest;
 import org.samtuap.inong.domain.farmNotice.dto.NoticeDetailResponse;
 import org.samtuap.inong.domain.farmNotice.dto.NoticeListResponse;
 import org.samtuap.inong.domain.farmNotice.service.FarmNoticeService;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -32,8 +30,21 @@ public class FarmNoticeController {
      */
     @GetMapping("/{farm_id}/notice/{notice_id}")
     public NoticeDetailResponse noticeDetail(@PathVariable("farm_id") Long farmId,
-                                           @PathVariable("notice_id") Long noticeId) {
+                                             @PathVariable("notice_id") Long noticeId) {
 
         return farmNoticeService.noticeDetail(farmId, noticeId);
+    }
+
+    /**
+     * 유저가 공지글에 댓글 작성
+     * 나중에 수정할 예정이기 때문에 memberId만 requestParam으로 받았음
+     */
+    @PostMapping("/{farm_id}/notice/{notice_id}/comment/create")
+    public void commentCreate(@PathVariable("farm_id") Long farmId,
+                              @PathVariable("notice_id") Long noticeId,
+                              @RequestParam("memberId") Long memberId,
+                              @RequestBody CommentCreateRequest dto) {
+
+        farmNoticeService.commentCreate(farmId, noticeId, memberId, dto);
     }
 }

--- a/backend/product/src/main/java/org/samtuap/inong/domain/farmNotice/dto/CommentCreateRequest.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/farmNotice/dto/CommentCreateRequest.java
@@ -1,0 +1,20 @@
+package org.samtuap.inong.domain.farmNotice.dto;
+
+import lombok.Builder;
+import org.samtuap.inong.domain.farmNotice.entity.FarmNotice;
+import org.samtuap.inong.domain.farmNotice.entity.NoticeComment;
+
+@Builder
+public record CommentCreateRequest(
+        Long id,
+        String contents
+) {
+    public static NoticeComment to(CommentCreateRequest commentCreateRequest, FarmNotice farmNotice, Long memberId) {
+        return NoticeComment.builder()
+                .id(commentCreateRequest.id)
+                .contents(commentCreateRequest.contents)
+                .memberId(memberId) // 추후에 로그인한 회원의 정보를 가져오면 되기 때문에 변경될 예정 ⭐
+                .farmNotice(farmNotice)
+                .build();
+    }
+}

--- a/backend/product/src/main/java/org/samtuap/inong/domain/farmNotice/dto/CommentListResponse.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/farmNotice/dto/CommentListResponse.java
@@ -1,0 +1,19 @@
+package org.samtuap.inong.domain.farmNotice.dto;
+
+import lombok.Builder;
+import org.samtuap.inong.domain.farmNotice.entity.NoticeComment;
+
+@Builder
+public record CommentListResponse(
+    Long id,
+    String name,
+    String contents
+) {
+    public static CommentListResponse from(NoticeComment comment, String name) {
+        return CommentListResponse.builder()
+                .id(comment.getId())
+                .name(name)
+                .contents(comment.getContents())
+                .build();
+    }
+}

--- a/backend/product/src/main/java/org/samtuap/inong/domain/farmNotice/dto/MemberDetailResponse.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/farmNotice/dto/MemberDetailResponse.java
@@ -1,0 +1,8 @@
+package org.samtuap.inong.domain.farmNotice.dto;
+
+// product 모듈 내에서 > FeignClient를 통해 Member에서 가져온 회원 정보를 담은 dto
+public record MemberDetailResponse(
+        Long id,
+        String name,
+        String email) {
+}

--- a/backend/product/src/main/java/org/samtuap/inong/domain/farmNotice/entity/NoticeComment.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/farmNotice/entity/NoticeComment.java
@@ -2,7 +2,10 @@ package org.samtuap.inong.domain.farmNotice.entity;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 import org.samtuap.inong.domain.common.BaseEntity;
@@ -10,7 +13,10 @@ import org.samtuap.inong.domain.common.BaseEntity;
 @Entity
 @SQLDelete(sql = "UPDATE notice_comment SET deleted_at = now() WHERE id = ?")
 @SQLRestriction("deleted_at is NULL")
-@Builder
+@Builder // CommentCreateRequest부분 때문에 builder 필요
+@NoArgsConstructor
+@AllArgsConstructor // builder를 사용해야해서 NoArgs와 AllArgs 필요
+@Getter
 public class NoticeComment extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/product/src/main/java/org/samtuap/inong/domain/farmNotice/entity/NoticeComment.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/farmNotice/entity/NoticeComment.java
@@ -2,6 +2,7 @@ package org.samtuap.inong.domain.farmNotice.entity;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 import org.samtuap.inong.domain.common.BaseEntity;
@@ -9,6 +10,7 @@ import org.samtuap.inong.domain.common.BaseEntity;
 @Entity
 @SQLDelete(sql = "UPDATE notice_comment SET deleted_at = now() WHERE id = ?")
 @SQLRestriction("deleted_at is NULL")
+@Builder
 public class NoticeComment extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -21,5 +23,8 @@ public class NoticeComment extends BaseEntity {
     @NotNull
     @Column(columnDefinition = "varchar(300)")
     private String contents;
+
+    @NotNull
+    private Long memberId; // 회원 id 컬럼
 
 }

--- a/backend/product/src/main/java/org/samtuap/inong/domain/farmNotice/repository/NoticeCommentRepository.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/farmNotice/repository/NoticeCommentRepository.java
@@ -1,0 +1,9 @@
+package org.samtuap.inong.domain.farmNotice.repository;
+
+import org.samtuap.inong.domain.farmNotice.entity.NoticeComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NoticeCommentRepository extends JpaRepository<NoticeComment, Long> {
+}

--- a/backend/product/src/main/java/org/samtuap/inong/domain/farmNotice/repository/NoticeCommentRepository.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/farmNotice/repository/NoticeCommentRepository.java
@@ -1,9 +1,14 @@
 package org.samtuap.inong.domain.farmNotice.repository;
 
+import org.samtuap.inong.domain.farmNotice.entity.FarmNotice;
 import org.samtuap.inong.domain.farmNotice.entity.NoticeComment;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface NoticeCommentRepository extends JpaRepository<NoticeComment, Long> {
+
+    List<NoticeComment> findByFarmNotice(FarmNotice farmNotice);
 }

--- a/backend/product/src/main/java/org/samtuap/inong/domain/farmNotice/service/FarmNoticeService.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/farmNotice/service/FarmNoticeService.java
@@ -4,17 +4,20 @@ import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.samtuap.inong.domain.farm.entity.Farm;
 import org.samtuap.inong.domain.farm.repository.FarmRepository;
+import org.samtuap.inong.domain.farmNotice.dto.CommentCreateRequest;
 import org.samtuap.inong.domain.farmNotice.dto.NoticeDetailResponse;
 import org.samtuap.inong.domain.farmNotice.dto.NoticeListResponse;
 import org.samtuap.inong.domain.farmNotice.entity.FarmNotice;
 import org.samtuap.inong.domain.farmNotice.entity.FarmNoticeImage;
+import org.samtuap.inong.domain.farmNotice.entity.NoticeComment;
 import org.samtuap.inong.domain.farmNotice.repository.FarmNoticeImageRepository;
 import org.samtuap.inong.domain.farmNotice.repository.FarmNoticeRepository;
+import org.samtuap.inong.domain.farmNotice.repository.NoticeCommentRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -23,6 +26,7 @@ public class FarmNoticeService {
     private final FarmNoticeRepository farmNoticeRepository;
     private final FarmNoticeImageRepository farmNoticeImageRepository;
     private final FarmRepository farmRepository; // 농장 id 가져오기 위해 참조
+    private final NoticeCommentRepository noticeCommentRepository;
 
     /**
      * 공지 목록 조회 => 제목, 내용, 사진(슬라이더)
@@ -69,5 +73,26 @@ public class FarmNoticeService {
         NoticeDetailResponse dto = NoticeDetailResponse.from(farmNotice, noticeImages);
 
         return dto;
+    }
+
+    /**
+     * 유저가 공지글에 댓글 작성
+     */
+    @Transactional
+    public void commentCreate(Long farmId, Long noticeId, Long memberId, CommentCreateRequest dto) {
+
+        // 해당 id에 일치하는 농장 가져오기
+        Farm farm = farmRepository.findById(farmId).orElseThrow(
+                () -> new EntityNotFoundException("해당 id의 농장이 존재하지 않습니다.")
+        );
+
+        FarmNotice farmNotice = farmNoticeRepository.findByIdAndFarm(noticeId, farm);
+        // 공지사항이 존재하지 않는 경우 예외 처리
+        if (farmNotice == null) {
+            throw new EntityNotFoundException("해당 농장에 해당하는 공지사항이 존재하지 않습니다.");
+        }
+
+        NoticeComment noticeComment = CommentCreateRequest.to(dto, farmNotice, memberId);
+        noticeCommentRepository.save(noticeComment);
     }
 }

--- a/backend/product/src/main/java/org/samtuap/inong/domain/farmNotice/service/MemberFeign.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/farmNotice/service/MemberFeign.java
@@ -1,0 +1,15 @@
+package org.samtuap.inong.domain.farmNotice.service;
+
+import org.samtuap.inong.config.FeignConfig;
+import org.samtuap.inong.domain.farmNotice.dto.MemberDetailResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(name = "member-service", configuration = FeignConfig.class)
+public interface MemberFeign {
+
+    @GetMapping(value = "/member/{id}")
+    MemberDetailResponse getMemberById(@PathVariable("id") Long id);
+
+}


### PR DESCRIPTION
## 📌 PR 타입
<!-- [x] 이렇게하면 체크돼요 -->
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 리팩토링
- [ ] docs 작업


## 📄 작업 내용
<!-- ex) 구글 소셜 로그인 기능추가, 프로젝트 모집글 쓰기 API 작성 -->
- 농장 > 공지 : 유저가 댓글 달기 기능 추가
- 농장 > 공지 : 유저가 댓글 조회 기능 추가

## 📷 결과 화면
<!-- 포스트맨 실행결과를 캡처해주세요 -->

- 유저가 댓글 달기 기능 추가<br>
<img src="https://github.com/user-attachments/assets/e9505a57-8c3b-4719-aa68-f822b293cb47" width=600>
<img src="https://github.com/user-attachments/assets/b77890e8-d0a3-4070-a11f-e483013a5344" width=600>
<br><br> 

- 유저가 댓글 조회 기능 추가<br>
<img src="https://github.com/user-attachments/assets/04284b75-e85c-4c1f-a20a-d319adf3258a" width=600><br>

## ✔️ 기타 사항
<!-- 리뷰 받고 싶은 포인트를 적어주세요! -->
참고 사항입니다 ! 
member의 name/email을 feignClient 요청을 통해 받아와야 해서, 어쩔 수 없이 Member 모듈에서 memberDetail 조회 관련 메서드와 기능을 제가 만들었습니다 ! (담당자한테 전달 완료) 

## 🌳 작업 브랜치
<!--ex)  feat/IS-1  -->
closed #12 