### PR TITLE
chore: BaseCustomException과 에러 응답 객체 세팅

### DIFF
--- a/backend/live/src/main/java/org/samtuap/inong/common/exception/BaseCustomException.java
+++ b/backend/live/src/main/java/org/samtuap/inong/common/exception/BaseCustomException.java
@@ -1,0 +1,15 @@
+package org.samtuap.inong.common.exception;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.samtuap.inong.common.exceptionType.ExceptionType;
+
+@RequiredArgsConstructor
+@Getter
+public class BaseCustomException extends RuntimeException {
+    private final ExceptionType exceptionType;
+
+    @Override
+    public String getMessage() {
+        return exceptionType.message();
+    }
+}

--- a/backend/live/src/main/java/org/samtuap/inong/common/exceptionType/ExceptionType.java
+++ b/backend/live/src/main/java/org/samtuap/inong/common/exceptionType/ExceptionType.java
@@ -1,0 +1,11 @@
+package org.samtuap.inong.common.exceptionType;
+
+import org.springframework.http.HttpStatus;
+
+public interface ExceptionType {
+    String name();
+
+    HttpStatus httpStatus();
+
+    String message();
+}

--- a/backend/live/src/main/java/org/samtuap/inong/common/handler/GlobalExceptionHandler.java
+++ b/backend/live/src/main/java/org/samtuap/inong/common/handler/GlobalExceptionHandler.java
@@ -1,0 +1,35 @@
+package org.samtuap.inong.common.handler;
+
+import lombok.extern.slf4j.Slf4j;
+import org.samtuap.inong.common.exception.BaseCustomException;
+import org.samtuap.inong.common.exceptionType.ExceptionType;
+import org.samtuap.inong.common.response.CustomErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(BaseCustomException.class)
+    public ResponseEntity<CustomErrorResponse> handleBaseException(BaseCustomException e) {
+        ExceptionType exceptionType = e.getExceptionType();
+        e.printStackTrace();
+        return ResponseEntity.status(exceptionType.httpStatus())
+                .body(CustomErrorResponse.of(exceptionType));
+    }
+
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<CustomErrorResponse> handleException(Exception e) {
+        log.error("[Unhandled Error] {}", e.getMessage());
+        e.printStackTrace();
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(CustomErrorResponse.builder()
+                        .name(HttpStatus.INTERNAL_SERVER_ERROR.name())
+                        .httpStatusCode(HttpStatus.INTERNAL_SERVER_ERROR.value())
+                        .message("서버 에러입니다.")
+                        .build());
+    }
+}

--- a/backend/live/src/main/java/org/samtuap/inong/common/response/CustomErrorResponse.java
+++ b/backend/live/src/main/java/org/samtuap/inong/common/response/CustomErrorResponse.java
@@ -1,0 +1,24 @@
+package org.samtuap.inong.common.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.samtuap.inong.common.exceptionType.ExceptionType;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class CustomErrorResponse {
+    String name; // exception의 이름
+    int httpStatusCode; // http 상태코드
+    String message; // 에러 메시지
+
+    public static CustomErrorResponse of(ExceptionType e) {
+        return CustomErrorResponse.builder()
+                .name(e.name())
+                .httpStatusCode(e.httpStatus().value())
+                .message(e.message())
+                .build();
+    }
+}

--- a/backend/member/src/main/java/org/samtuap/inong/common/exception/BaseCustomException.java
+++ b/backend/member/src/main/java/org/samtuap/inong/common/exception/BaseCustomException.java
@@ -1,0 +1,15 @@
+package org.samtuap.inong.common.exception;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.samtuap.inong.common.exceptionType.ExceptionType;
+
+@RequiredArgsConstructor
+@Getter
+public class BaseCustomException extends RuntimeException {
+    private final ExceptionType exceptionType;
+
+    @Override
+    public String getMessage() {
+        return exceptionType.message();
+    }
+}

--- a/backend/member/src/main/java/org/samtuap/inong/common/exceptionType/ExceptionType.java
+++ b/backend/member/src/main/java/org/samtuap/inong/common/exceptionType/ExceptionType.java
@@ -1,0 +1,11 @@
+package org.samtuap.inong.common.exceptionType;
+
+import org.springframework.http.HttpStatus;
+
+public interface ExceptionType {
+    String name();
+
+    HttpStatus httpStatus();
+
+    String message();
+}

--- a/backend/member/src/main/java/org/samtuap/inong/common/handler/GlobalExceptionHandler.java
+++ b/backend/member/src/main/java/org/samtuap/inong/common/handler/GlobalExceptionHandler.java
@@ -1,0 +1,35 @@
+package org.samtuap.inong.common.handler;
+
+import lombok.extern.slf4j.Slf4j;
+import org.samtuap.inong.common.exception.BaseCustomException;
+import org.samtuap.inong.common.exceptionType.ExceptionType;
+import org.samtuap.inong.common.response.CustomErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(BaseCustomException.class)
+    public ResponseEntity<CustomErrorResponse> handleBaseException(BaseCustomException e) {
+        ExceptionType exceptionType = e.getExceptionType();
+        e.printStackTrace();
+        return ResponseEntity.status(exceptionType.httpStatus())
+                .body(CustomErrorResponse.of(exceptionType));
+    }
+
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<CustomErrorResponse> handleException(Exception e) {
+        log.error("[Unhandled Error] {}", e.getMessage());
+        e.printStackTrace();
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(CustomErrorResponse.builder()
+                        .name(HttpStatus.INTERNAL_SERVER_ERROR.name())
+                        .httpStatusCode(HttpStatus.INTERNAL_SERVER_ERROR.value())
+                        .message("서버 에러입니다.")
+                        .build());
+    }
+}

--- a/backend/member/src/main/java/org/samtuap/inong/common/response/CustomErrorResponse.java
+++ b/backend/member/src/main/java/org/samtuap/inong/common/response/CustomErrorResponse.java
@@ -1,0 +1,24 @@
+package org.samtuap.inong.common.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.samtuap.inong.common.exceptionType.ExceptionType;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class CustomErrorResponse {
+    String name; // exception의 이름
+    int httpStatusCode; // http 상태코드
+    String message; // 에러 메시지
+
+    public static CustomErrorResponse of(ExceptionType e) {
+        return CustomErrorResponse.builder()
+                .name(e.name())
+                .httpStatusCode(e.httpStatus().value())
+                .message(e.message())
+                .build();
+    }
+}

--- a/backend/order/src/main/java/org/samtuap/inong/common/exception/BaseCustomException.java
+++ b/backend/order/src/main/java/org/samtuap/inong/common/exception/BaseCustomException.java
@@ -1,0 +1,15 @@
+package org.samtuap.inong.common.exception;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.samtuap.inong.common.exceptionType.ExceptionType;
+
+@RequiredArgsConstructor
+@Getter
+public class BaseCustomException extends RuntimeException {
+    private final ExceptionType exceptionType;
+
+    @Override
+    public String getMessage() {
+        return exceptionType.message();
+    }
+}

--- a/backend/order/src/main/java/org/samtuap/inong/common/exceptionType/ExceptionType.java
+++ b/backend/order/src/main/java/org/samtuap/inong/common/exceptionType/ExceptionType.java
@@ -1,0 +1,11 @@
+package org.samtuap.inong.common.exceptionType;
+
+import org.springframework.http.HttpStatus;
+
+public interface ExceptionType {
+    String name();
+
+    HttpStatus httpStatus();
+
+    String message();
+}

--- a/backend/order/src/main/java/org/samtuap/inong/common/handler/GlobalExceptionHandler.java
+++ b/backend/order/src/main/java/org/samtuap/inong/common/handler/GlobalExceptionHandler.java
@@ -1,0 +1,35 @@
+package org.samtuap.inong.common.handler;
+
+import lombok.extern.slf4j.Slf4j;
+import org.samtuap.inong.common.exception.BaseCustomException;
+import org.samtuap.inong.common.exceptionType.ExceptionType;
+import org.samtuap.inong.common.response.CustomErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(BaseCustomException.class)
+    public ResponseEntity<CustomErrorResponse> handleBaseException(BaseCustomException e) {
+        ExceptionType exceptionType = e.getExceptionType();
+        e.printStackTrace();
+        return ResponseEntity.status(exceptionType.httpStatus())
+                .body(CustomErrorResponse.of(exceptionType));
+    }
+
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<CustomErrorResponse> handleException(Exception e) {
+        log.error("[Unhandled Error] {}", e.getMessage());
+        e.printStackTrace();
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(CustomErrorResponse.builder()
+                        .name(HttpStatus.INTERNAL_SERVER_ERROR.name())
+                        .httpStatusCode(HttpStatus.INTERNAL_SERVER_ERROR.value())
+                        .message("서버 에러입니다.")
+                        .build());
+    }
+}

--- a/backend/order/src/main/java/org/samtuap/inong/common/response/CustomErrorResponse.java
+++ b/backend/order/src/main/java/org/samtuap/inong/common/response/CustomErrorResponse.java
@@ -1,0 +1,24 @@
+package org.samtuap.inong.common.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.samtuap.inong.common.exceptionType.ExceptionType;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class CustomErrorResponse {
+    String name; // exception의 이름
+    int httpStatusCode; // http 상태코드
+    String message; // 에러 메시지
+
+    public static CustomErrorResponse of(ExceptionType e) {
+        return CustomErrorResponse.builder()
+                .name(e.name())
+                .httpStatusCode(e.httpStatus().value())
+                .message(e.message())
+                .build();
+    }
+}

--- a/backend/product/src/main/java/org/samtuap/inong/common/exception/BaseCustomException.java
+++ b/backend/product/src/main/java/org/samtuap/inong/common/exception/BaseCustomException.java
@@ -1,0 +1,15 @@
+package org.samtuap.inong.common.exception;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.samtuap.inong.common.exceptionType.ExceptionType;
+
+@RequiredArgsConstructor
+@Getter
+public class BaseCustomException extends RuntimeException {
+    private final ExceptionType exceptionType;
+
+    @Override
+    public String getMessage() {
+        return exceptionType.message();
+    }
+}

--- a/backend/product/src/main/java/org/samtuap/inong/common/exceptionType/ExceptionType.java
+++ b/backend/product/src/main/java/org/samtuap/inong/common/exceptionType/ExceptionType.java
@@ -1,0 +1,11 @@
+package org.samtuap.inong.common.exceptionType;
+
+import org.springframework.http.HttpStatus;
+
+public interface ExceptionType {
+    String name();
+
+    HttpStatus httpStatus();
+
+    String message();
+}

--- a/backend/product/src/main/java/org/samtuap/inong/common/exceptionType/ProductExceptionType.java
+++ b/backend/product/src/main/java/org/samtuap/inong/common/exceptionType/ProductExceptionType.java
@@ -1,0 +1,22 @@
+package org.samtuap.inong.common.exceptionType;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum ProductExceptionType implements ExceptionType {
+    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 상품입니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public HttpStatus httpStatus() {
+        return status;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+}

--- a/backend/product/src/main/java/org/samtuap/inong/common/handler/GlobalExceptionHandler.java
+++ b/backend/product/src/main/java/org/samtuap/inong/common/handler/GlobalExceptionHandler.java
@@ -1,0 +1,35 @@
+package org.samtuap.inong.common.handler;
+
+import lombok.extern.slf4j.Slf4j;
+import org.samtuap.inong.common.exception.BaseCustomException;
+import org.samtuap.inong.common.exceptionType.ExceptionType;
+import org.samtuap.inong.common.response.CustomErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(BaseCustomException.class)
+    public ResponseEntity<CustomErrorResponse> handleBaseException(BaseCustomException e) {
+        ExceptionType exceptionType = e.getExceptionType();
+        e.printStackTrace();
+        return ResponseEntity.status(exceptionType.httpStatus())
+                .body(CustomErrorResponse.of(exceptionType));
+    }
+
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<CustomErrorResponse> handleException(Exception e) {
+        log.error("[Unhandled Error] {}", e.getMessage());
+        e.printStackTrace();
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(CustomErrorResponse.builder()
+                        .name(HttpStatus.INTERNAL_SERVER_ERROR.name())
+                        .httpStatusCode(HttpStatus.INTERNAL_SERVER_ERROR.value())
+                        .message("서버 에러입니다.")
+                        .build());
+    }
+}

--- a/backend/product/src/main/java/org/samtuap/inong/common/response/CustomErrorResponse.java
+++ b/backend/product/src/main/java/org/samtuap/inong/common/response/CustomErrorResponse.java
@@ -1,0 +1,24 @@
+package org.samtuap.inong.common.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.samtuap.inong.common.exceptionType.ExceptionType;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class CustomErrorResponse {
+    String name; // exception의 이름
+    int httpStatusCode; // http 상태코드
+    String message; // 에러 메시지
+
+    public static CustomErrorResponse of(ExceptionType e) {
+        return CustomErrorResponse.builder()
+                .name(e.name())
+                .httpStatusCode(e.httpStatus().value())
+                .message(e.message())
+                .build();
+    }
+}

--- a/backend/product/src/main/java/org/samtuap/inong/domain/product/api/ProductController.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/product/api/ProductController.java
@@ -1,8 +1,12 @@
 package org.samtuap.inong.domain.product.api;
 
+import org.samtuap.inong.common.exception.BaseCustomException;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import static org.samtuap.inong.common.exceptionType.ProductExceptionType.PRODUCT_NOT_FOUND;
+
 
 @RequestMapping("/product")
 @RestController
@@ -10,5 +14,10 @@ public class ProductController {
     @GetMapping
     public String testApi() {
         return "product-test!!";
+    }
+
+    @GetMapping("/test")
+    public void exceptionTest() {
+        throw new BaseCustomException(PRODUCT_NOT_FOUND);
     }
 }


### PR DESCRIPTION
## 📌 PR 타입
<!-- [x] 이렇게하면 체크돼요 -->
- [ ] 기능 추가
- [ ] 기능 수정
- [ ] 리팩토링
- [ ] docs 작업
- [x] 기타


## 📄 작업 내용
<!-- ex) 구글 소셜 로그인 기능추가, 프로젝트 모집글 쓰기 API 작성 -->
- 4개의 모듈에 BaseCustomException 객체와 ExceptionType을 만들었습니다.
- 4개의 모듈에 GlocalExceptionHandler를 추가했습니다.


## 📷 결과 화면
<!-- 포스트맨 실행결과를 캡처해주세요 -->
Exception이 잘 떨어지는지 테스트하는 API를 만들었습니다.
<img width="1280" alt="스크린샷 2024-09-19 오후 12 44 09" src="https://github.com/user-attachments/assets/3501fc56-3ef5-49ec-9300-30df4d92ff09">


## ✔️ 기타 사항
<!-- 리뷰 받고 싶은 포인트를 적어주세요! -->
이제 Exception을 발생시킬때 모두 BaseCustomException에 적절한 ExceptionType을 넣어서 던져주시면 감사하겠습니다!!

## 🌳 작업 브랜치
<!--ex)  feat/IS-1  -->
chore/20
closed #20 