### PR TITLE
feat: 판매자 정보 조회

### DIFF
--- a/backend/product/src/main/java/org/samtuap/inong/domain/farm/entity/FarmCategory.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/farm/entity/FarmCategory.java
@@ -5,10 +5,12 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 import org.samtuap.inong.domain.common.BaseEntity;
 
+@Getter
 @Entity
 public class FarmCategory extends BaseEntity {
     @Id

--- a/backend/product/src/main/java/org/samtuap/inong/domain/farm/entity/FarmCategoryRelation.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/farm/entity/FarmCategoryRelation.java
@@ -1,9 +1,11 @@
 package org.samtuap.inong.domain.farm.entity;
 
 import jakarta.persistence.*;
+import lombok.Getter;
 import org.hibernate.annotations.SQLDelete;
 import org.samtuap.inong.domain.common.BaseEntity;
 
+@Getter
 @Entity
 public class FarmCategoryRelation extends BaseEntity {
     @Id

--- a/backend/product/src/main/java/org/samtuap/inong/domain/farm/repository/FarmCategoryRelationRepository.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/farm/repository/FarmCategoryRelationRepository.java
@@ -1,0 +1,10 @@
+package org.samtuap.inong.domain.farm.repository;
+
+import org.samtuap.inong.domain.farm.entity.FarmCategoryRelation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+
+public interface FarmCategoryRelationRepository extends JpaRepository<FarmCategoryRelation, Long> {
+    FarmCategoryRelation findByFarmId(Long farmId);
+}

--- a/backend/product/src/main/java/org/samtuap/inong/domain/farm/repository/FarmCategoryRepository.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/farm/repository/FarmCategoryRepository.java
@@ -1,0 +1,13 @@
+package org.samtuap.inong.domain.farm.repository;
+
+import org.samtuap.inong.common.exception.BaseCustomException;
+import org.samtuap.inong.domain.farm.entity.FarmCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import static org.samtuap.inong.common.exceptionType.ProductExceptionType.FARM_NOT_FOUND;
+
+public interface FarmCategoryRepository extends JpaRepository<FarmCategory, Long> {
+    default FarmCategory findByIdOrThrow(Long categoryId) {
+        return findById(categoryId).orElseThrow(() -> new BaseCustomException(FARM_NOT_FOUND));
+    }
+}

--- a/backend/product/src/main/java/org/samtuap/inong/domain/seller/dto/SellerInfoResponse.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/seller/dto/SellerInfoResponse.java
@@ -2,6 +2,7 @@ package org.samtuap.inong.domain.seller.dto;
 
 import lombok.Builder;
 import org.samtuap.inong.domain.farm.entity.Farm;
+import org.samtuap.inong.domain.farm.entity.FarmCategory;
 import org.samtuap.inong.domain.seller.entity.Seller;
 
 @Builder
@@ -10,15 +11,17 @@ public record SellerInfoResponse(
         String email,
         String businessName,
         String farmName,
-        String farmIntro
+        String farmIntro,
+        String categoryTitle
 ) {
-    public static SellerInfoResponse fromEntity(Seller seller, Farm farm) {
+    public static SellerInfoResponse fromEntity(Seller seller, Farm farm, FarmCategory category) {
         return SellerInfoResponse.builder()
                 .name(seller.getName())
                 .email(seller.getEmail())
                 .businessName(seller.getBusinessName())
                 .farmName(farm.getFarmName())
                 .farmIntro(farm.getFarmIntro())
+                .categoryTitle(category.getTitle())
                 .build();
     }
 }

--- a/backend/product/src/main/java/org/samtuap/inong/domain/seller/service/SellerService.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/seller/service/SellerService.java
@@ -4,6 +4,10 @@ import lombok.RequiredArgsConstructor;
 import org.mindrot.jbcrypt.BCrypt;
 import org.samtuap.inong.common.exception.BaseCustomException;
 import org.samtuap.inong.domain.farm.entity.Farm;
+import org.samtuap.inong.domain.farm.entity.FarmCategory;
+import org.samtuap.inong.domain.farm.entity.FarmCategoryRelation;
+import org.samtuap.inong.domain.farm.repository.FarmCategoryRelationRepository;
+import org.samtuap.inong.domain.farm.repository.FarmCategoryRepository;
 import org.samtuap.inong.domain.farm.repository.FarmRepository;
 import org.samtuap.inong.domain.seller.dto.SellerInfoResponse;
 import org.samtuap.inong.domain.seller.dto.SellerSignInRequest;
@@ -13,11 +17,11 @@ import org.samtuap.inong.domain.seller.entity.Seller;
 import org.samtuap.inong.domain.seller.jwt.domain.JwtToken;
 import org.samtuap.inong.domain.seller.jwt.service.JwtService;
 import org.samtuap.inong.domain.seller.repository.SellerRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import static org.samtuap.inong.common.exceptionType.ProductExceptionType.*;
+import static org.samtuap.inong.common.exceptionType.ProductExceptionType.EMAIL_NOT_FOUND;
+import static org.samtuap.inong.common.exceptionType.ProductExceptionType.INVALID_PASSWORD;
 
 @RequiredArgsConstructor
 @Service
@@ -26,6 +30,8 @@ public class SellerService {
 
     private final SellerRepository sellerRepository;
     private final FarmRepository farmRepository;
+    private final FarmCategoryRepository farmCategoryRepository;
+    private final FarmCategoryRelationRepository farmCategoryRelationRepository;
     private final JwtService jwtService;
 
     @Transactional
@@ -68,8 +74,10 @@ public class SellerService {
     public SellerInfoResponse getSellerInfo(Long sellerId) {
         Seller seller = sellerRepository.findByIdOrThrow(sellerId);
         Farm farm = farmRepository.findBySellerIdOrThrow(sellerId);
+        FarmCategoryRelation categoryRelation = farmCategoryRelationRepository.findByFarmId(farm.getId());
+        FarmCategory farmCategory = farmCategoryRepository.findByIdOrThrow(categoryRelation.getCategory().getId());
 
-        return SellerInfoResponse.fromEntity(seller, farm);
+        return SellerInfoResponse.fromEntity(seller, farm, farmCategory);
     }
 
 }


### PR DESCRIPTION
## 📌 PR 타입
<!-- [x] 이렇게하면 체크돼요 -->
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 리팩토링
- [ ] docs 작업


## 📄 작업 내용
<!-- ex) 구글 소셜 로그인 기능추가, 프로젝트 모집글 쓰기 API 작성 -->
판매자는 자신의 정보 및 자신의 농장 정보를 조회할 수 있다.
**브랜치 실수로 미리 push 되어 카테고리 관련 수정 사항만 반영되어 있으나 feature 로 처리하였습니다 !**

## 📷 결과 화면
<!-- 포스트맨 실행결과를 캡처해주세요 -->
![스크린샷 2024-09-20 오후 10 42 09](https://github.com/user-attachments/assets/2efbbb2c-1735-4194-b423-722aa117e8cb)

## ✔️ 기타 사항
<!-- 리뷰 받고 싶은 포인트를 적어주세요! -->

## 🌳 작업 브랜치
<!--ex)  feat/IS-1  -->
closed #59 