### PR TITLE
feature: 판매자 > 사장님 페이지 > 주문 및 배송 내역 조회2

### DIFF
--- a/backend/order/src/main/java/org/samtuap/inong/common/exceptionType/DeliveryExceptionType.java
+++ b/backend/order/src/main/java/org/samtuap/inong/common/exceptionType/DeliveryExceptionType.java
@@ -1,0 +1,22 @@
+package org.samtuap.inong.common.exceptionType;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum DeliveryExceptionType  implements ExceptionType{
+    DELIVERY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 id의 배송건이 존재하지 않습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public HttpStatus httpStatus() {
+        return status;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+}

--- a/backend/order/src/main/java/org/samtuap/inong/domain/delivery/api/DeliveryController.java
+++ b/backend/order/src/main/java/org/samtuap/inong/domain/delivery/api/DeliveryController.java
@@ -1,7 +1,9 @@
 package org.samtuap.inong.domain.delivery.api;
 
 import lombok.RequiredArgsConstructor;
+import org.samtuap.inong.domain.delivery.dto.BillingNumberCreateRequest;
 import org.samtuap.inong.domain.delivery.dto.DeliveryUpComingListResponse;
+import org.samtuap.inong.domain.delivery.entity.Delivery;
 import org.samtuap.inong.domain.delivery.service.DeliveryService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -9,9 +11,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 
 @RestController
@@ -29,5 +29,15 @@ public class DeliveryController {
             @PageableDefault(size = 10, sort = "deliveryAt", direction = Sort.Direction.ASC) Pageable pageable) {
         Page<DeliveryUpComingListResponse> list = deliveryService.upcomingDelivery(pageable);
         return new ResponseEntity<>(list, HttpStatus.OK);
+    }
+
+    /**
+     * 사장님 페이지 > 운송장 번호를 등록하면 delivery 엔티티의 status가 IN_DELIVERY로 변경
+     */
+    @PatchMapping("/createBillingNumber/{id}")
+    public ResponseEntity<?> createBillingNumber(@PathVariable("id") Long id,
+                                                        @RequestBody BillingNumberCreateRequest dto) {
+        deliveryService.createBillingNumber(id, dto);
+        return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/backend/order/src/main/java/org/samtuap/inong/domain/delivery/api/DeliveryController.java
+++ b/backend/order/src/main/java/org/samtuap/inong/domain/delivery/api/DeliveryController.java
@@ -2,8 +2,8 @@ package org.samtuap.inong.domain.delivery.api;
 
 import lombok.RequiredArgsConstructor;
 import org.samtuap.inong.domain.delivery.dto.BillingNumberCreateRequest;
+import org.samtuap.inong.domain.delivery.dto.DeliveryCompletedListResponse;
 import org.samtuap.inong.domain.delivery.dto.DeliveryUpComingListResponse;
-import org.samtuap.inong.domain.delivery.entity.Delivery;
 import org.samtuap.inong.domain.delivery.service.DeliveryService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -36,8 +36,19 @@ public class DeliveryController {
      */
     @PatchMapping("/createBillingNumber/{id}")
     public ResponseEntity<?> createBillingNumber(@PathVariable("id") Long id,
-                                                        @RequestBody BillingNumberCreateRequest dto) {
+                                                 @RequestBody BillingNumberCreateRequest dto) {
         deliveryService.createBillingNumber(id, dto);
         return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    /**
+     * 사장님 페이지 > 처리한 배송 조회
+     * 정렬) IN_DELIVERY가 먼저 출력되고 그다음 AFTER_DELIVERY가 출력되도록 함 > 그 안에서는 배송날짜로 DESC 정렬
+     */
+    @GetMapping("/completed/list")
+    public ResponseEntity<Page<DeliveryCompletedListResponse>> completedDelivery(
+            @PageableDefault(size = 10, sort = {"deliveryStatus", "deliveryAt"}, direction = Sort.Direction.DESC) Pageable pageable) {
+        Page<DeliveryCompletedListResponse> list = deliveryService.completedDelivery(pageable);
+        return new ResponseEntity<>(list, HttpStatus.OK);
     }
 }

--- a/backend/order/src/main/java/org/samtuap/inong/domain/delivery/dto/BillingNumberCreateRequest.java
+++ b/backend/order/src/main/java/org/samtuap/inong/domain/delivery/dto/BillingNumberCreateRequest.java
@@ -1,0 +1,11 @@
+package org.samtuap.inong.domain.delivery.dto;
+
+import lombok.Builder;
+
+@Builder
+public record BillingNumberCreateRequest(
+        Long id,
+        String billingNumber
+) {
+
+}

--- a/backend/order/src/main/java/org/samtuap/inong/domain/delivery/dto/DeliveryCompletedListResponse.java
+++ b/backend/order/src/main/java/org/samtuap/inong/domain/delivery/dto/DeliveryCompletedListResponse.java
@@ -1,0 +1,25 @@
+package org.samtuap.inong.domain.delivery.dto;
+
+import lombok.Builder;
+import org.samtuap.inong.domain.delivery.entity.Delivery;
+
+@Builder
+public record DeliveryCompletedListResponse(
+        Long id,
+        String memberName,
+        String packageProductName,
+        String deliveryAt,
+        String billingNumber,
+        String deliveryStatus
+) {
+    public static DeliveryCompletedListResponse from(Delivery delivery, String memberName, String packageProductName) {
+        return DeliveryCompletedListResponse.builder()
+                .id(delivery.getId())
+                .memberName(memberName)
+                .packageProductName(packageProductName)
+                .deliveryAt(String.valueOf(delivery.getDeliveryAt()))
+                .billingNumber(delivery.getBillingNumber())
+                .deliveryStatus(String.valueOf(delivery.getDeliveryStatus()))
+                .build();
+    }
+}

--- a/backend/order/src/main/java/org/samtuap/inong/domain/delivery/entity/Delivery.java
+++ b/backend/order/src/main/java/org/samtuap/inong/domain/delivery/entity/Delivery.java
@@ -1,8 +1,12 @@
 package org.samtuap.inong.domain.delivery.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 import org.samtuap.inong.domain.common.BaseEntity;
@@ -15,6 +19,9 @@ import java.time.LocalDateTime;
 @SQLDelete(sql = "UPDATE coupon SET deleted_at = now() WHERE id = ?")
 @SQLRestriction("deleted_at is NULL")
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Delivery extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -35,5 +42,10 @@ public class Delivery extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "ordering_id")
     private Ordering ordering;
+
+    public void updateDelivery(String billingNumber, DeliveryStatus deliveryStatus) {
+        this.billingNumber = billingNumber;
+        this.deliveryStatus = deliveryStatus;
+    }
 
 }

--- a/backend/order/src/main/java/org/samtuap/inong/domain/delivery/repository/DeliveryRepository.java
+++ b/backend/order/src/main/java/org/samtuap/inong/domain/delivery/repository/DeliveryRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.samtuap.inong.common.exceptionType.DeliveryExceptionType.DELIVERY_NOT_FOUND;
 
@@ -22,4 +23,6 @@ public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
     default Delivery findByIdOrThrow(Long id) {
         return findById(id).orElseThrow(()->new BaseCustomException(DELIVERY_NOT_FOUND));
     }
+
+    Page<Delivery> findByDeliveryStatusIn(List<DeliveryStatus> statuses, Pageable pageable);
 }

--- a/backend/order/src/main/java/org/samtuap/inong/domain/delivery/repository/DeliveryRepository.java
+++ b/backend/order/src/main/java/org/samtuap/inong/domain/delivery/repository/DeliveryRepository.java
@@ -1,5 +1,6 @@
 package org.samtuap.inong.domain.delivery.repository;
 
+import org.samtuap.inong.common.exception.BaseCustomException;
 import org.samtuap.inong.domain.delivery.entity.Delivery;
 import org.samtuap.inong.domain.delivery.entity.DeliveryStatus;
 import org.springframework.data.domain.Page;
@@ -9,10 +10,16 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
 
+import static org.samtuap.inong.common.exceptionType.DeliveryExceptionType.DELIVERY_NOT_FOUND;
+
 @Repository
 public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
 
     Page<Delivery> findByDeliveryStatusAndDeliveryAtBefore(DeliveryStatus deliveryStatus,
                                                            LocalDateTime endDate,
                                                            Pageable pageable);
+
+    default Delivery findByIdOrThrow(Long id) {
+        return findById(id).orElseThrow(()->new BaseCustomException(DELIVERY_NOT_FOUND));
+    }
 }

--- a/backend/order/src/main/java/org/samtuap/inong/domain/delivery/service/DeliveryService.java
+++ b/backend/order/src/main/java/org/samtuap/inong/domain/delivery/service/DeliveryService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.samtuap.inong.common.client.MemberFeign;
 import org.samtuap.inong.common.client.ProductFeign;
+import org.samtuap.inong.domain.delivery.dto.BillingNumberCreateRequest;
 import org.samtuap.inong.domain.delivery.dto.DeliveryUpComingListResponse;
 import org.samtuap.inong.domain.delivery.dto.MemberDetailResponse;
 import org.samtuap.inong.domain.delivery.dto.PackageProductResponse;
@@ -13,6 +14,7 @@ import org.samtuap.inong.domain.delivery.repository.DeliveryRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
@@ -42,5 +44,20 @@ public class DeliveryService {
             // DeliveryUpComingListResponse 생성
             return DeliveryUpComingListResponse.from(delivery, member.name(), packageProduct.packageName());
         });
+    }
+
+    /**
+     * 사장님 페이지 > 운송장 번호를 등록하면 delivery 엔티티의 status가 IN_DELIVERY로 변경
+     */
+    @Transactional
+    public void createBillingNumber(Long id, BillingNumberCreateRequest dto) {
+
+        Delivery delivery = deliveryRepository.findByIdOrThrow(id);
+
+        // delivery의 운송장 번호 추가 및 상태 변경
+        if (dto.billingNumber() != null) {
+            delivery.updateDelivery(dto.billingNumber(), DeliveryStatus.IN_DELIVERY);
+        }
+        deliveryRepository.save(delivery);
     }
 }

--- a/backend/order/src/main/java/org/samtuap/inong/domain/delivery/service/DeliveryService.java
+++ b/backend/order/src/main/java/org/samtuap/inong/domain/delivery/service/DeliveryService.java
@@ -4,10 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.samtuap.inong.common.client.MemberFeign;
 import org.samtuap.inong.common.client.ProductFeign;
-import org.samtuap.inong.domain.delivery.dto.BillingNumberCreateRequest;
-import org.samtuap.inong.domain.delivery.dto.DeliveryUpComingListResponse;
-import org.samtuap.inong.domain.delivery.dto.MemberDetailResponse;
-import org.samtuap.inong.domain.delivery.dto.PackageProductResponse;
+import org.samtuap.inong.domain.delivery.dto.*;
 import org.samtuap.inong.domain.delivery.entity.Delivery;
 import org.samtuap.inong.domain.delivery.entity.DeliveryStatus;
 import org.samtuap.inong.domain.delivery.repository.DeliveryRepository;
@@ -17,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -59,5 +57,22 @@ public class DeliveryService {
             delivery.updateDelivery(dto.billingNumber(), DeliveryStatus.IN_DELIVERY);
         }
         deliveryRepository.save(delivery);
+    }
+
+    /**
+     * 사장님 페이지 > 처리한 배송 조회
+     */
+    public Page<DeliveryCompletedListResponse> completedDelivery(Pageable pageable) {
+
+        // IN_DELIVERY, AFTER_DELIVERY인 배송건 가져오기
+        List<DeliveryStatus> statuses = List.of(DeliveryStatus.IN_DELIVERY, DeliveryStatus.AFTER_DELIVERY);
+        Page<Delivery> deliveries = deliveryRepository.findByDeliveryStatusIn(statuses, pageable);
+
+        return deliveries.map(delivery -> {
+            MemberDetailResponse member = memberFeign.getMemberById(delivery.getOrdering().getMemberId());
+            PackageProductResponse packageProduct = productFeign.getPackageProduct(delivery.getOrdering().getPackageId());
+
+            return DeliveryCompletedListResponse.from(delivery, member.name(), packageProduct.packageName());
+        });
     }
 }


### PR DESCRIPTION
## 📌 PR 타입
<!-- [x] 이렇게하면 체크돼요 -->
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 리팩토링
- [ ] docs 작업


## 📄 작업 내용
<!-- ex) 구글 소셜 로그인 기능추가, 프로젝트 모집글 쓰기 API 작성 -->
- 판매자 > 사장님 페이지 > 주문 및 배송 내역 조회2


## 📷 결과 화면
<!-- 포스트맨 실행결과를 캡처해주세요 -->
-  운송장 번호를 추가하면 delivery 엔티티에 추가되고 status가 변경되는 기능 추가 
<img src="https://github.com/user-attachments/assets/efa00613-ffd0-4d42-83c2-341c22026e41" width=600>
<img src="https://github.com/user-attachments/assets/79347ab7-dc06-4d74-a364-ba0b9791d1d4" width=600><br>
운송장 번호가 등록되고, status가 BEFORE_DELIVERY > IN_DELIVERY로 변경됨 
<br><br>


-  status가 IN_DELIVERY, AFTER_DELIVERY인 '처리된 배송'목록 조회 기능 추가
<img src="https://github.com/user-attachments/assets/bc513eac-2f71-4ba9-88d5-1b82c6a36ae1" width=600>
<img src="https://github.com/user-attachments/assets/3de067d3-dadf-4de0-9827-d7780fa55b95" width=450><br>
먼저 status로 정렬된 후, deliveryat으로 각각 내림차순 정렬된 것을 볼 수 있음 <br>
+) 참고사항 => id=3 주문건은 두번 출력된게 아니라, 캡처에서 겹친 것임 


## ✔️ 기타 사항
<!-- 리뷰 받고 싶은 포인트를 적어주세요! -->

## 🌳 작업 브랜치
<!--ex)  feat/IS-1  -->
closed #65 