### PR TITLE
chore: 사장님 페이지 > 주문 및 배송관리 코드 수정

### DIFF
--- a/backend/order/src/main/java/org/samtuap/inong/common/client/ProductFeign.java
+++ b/backend/order/src/main/java/org/samtuap/inong/common/client/ProductFeign.java
@@ -1,6 +1,7 @@
 package org.samtuap.inong.common.client;
 
 import org.samtuap.inong.config.FeignConfig;
+import org.samtuap.inong.domain.delivery.dto.FarmDetailGetResponse;
 import org.samtuap.inong.domain.delivery.dto.PackageProductResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,5 +12,8 @@ public interface ProductFeign {
 
     @GetMapping(value = "/product/info/{id}")
     PackageProductResponse getPackageProduct(@PathVariable("id") Long packageProductId);
+
+    @GetMapping(value = "/farm/seller/{sellerId}")
+    FarmDetailGetResponse getFarmInfoWithSeller(@PathVariable("sellerId") Long sellerId);
 
 }

--- a/backend/order/src/main/java/org/samtuap/inong/domain/delivery/api/DeliveryController.java
+++ b/backend/order/src/main/java/org/samtuap/inong/domain/delivery/api/DeliveryController.java
@@ -50,8 +50,9 @@ public class DeliveryController {
      */
     @GetMapping("/completed/list")
     public ResponseEntity<Page<DeliveryCompletedListResponse>> completedDelivery(
+            @RequestHeader("sellerId") Long sellerId,
             @PageableDefault(size = 10, sort = {"deliveryStatus", "deliveryAt"}, direction = Sort.Direction.DESC) Pageable pageable) {
-        Page<DeliveryCompletedListResponse> list = deliveryService.completedDelivery(pageable);
+        Page<DeliveryCompletedListResponse> list = deliveryService.completedDelivery(sellerId, pageable);
         return new ResponseEntity<>(list, HttpStatus.OK);
     }
 }

--- a/backend/order/src/main/java/org/samtuap/inong/domain/delivery/api/DeliveryController.java
+++ b/backend/order/src/main/java/org/samtuap/inong/domain/delivery/api/DeliveryController.java
@@ -1,6 +1,7 @@
 package org.samtuap.inong.domain.delivery.api;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.samtuap.inong.domain.delivery.dto.BillingNumberCreateRequest;
 import org.samtuap.inong.domain.delivery.dto.DeliveryCompletedListResponse;
 import org.samtuap.inong.domain.delivery.dto.DeliveryUpComingListResponse;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/delivery")
 @RequiredArgsConstructor
+@Slf4j
 public class DeliveryController {
 
     private final DeliveryService deliveryService;
@@ -26,8 +28,9 @@ public class DeliveryController {
      */
     @GetMapping("/upcoming/list")
     public ResponseEntity<Page<DeliveryUpComingListResponse>> upcomingDelivery(
+            @RequestHeader("sellerId") Long sellerId,
             @PageableDefault(size = 10, sort = "deliveryDueDate", direction = Sort.Direction.ASC) Pageable pageable) {
-        Page<DeliveryUpComingListResponse> list = deliveryService.upcomingDelivery(pageable);
+        Page<DeliveryUpComingListResponse> list = deliveryService.upcomingDelivery(sellerId, pageable);
         return new ResponseEntity<>(list, HttpStatus.OK);
     }
 

--- a/backend/order/src/main/java/org/samtuap/inong/domain/delivery/dto/FarmDetailGetResponse.java
+++ b/backend/order/src/main/java/org/samtuap/inong/domain/delivery/dto/FarmDetailGetResponse.java
@@ -1,0 +1,13 @@
+package org.samtuap.inong.domain.delivery.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+@Builder
+public record FarmDetailGetResponse(@NotNull Long id,
+                                    @NotNull String farmName,
+                                    @NotNull String bannerImageUrl,
+                                    @NotNull String profileImageUrl,
+                                    @NotNull String farmIntro,
+                                    @NotNull Long favoriteCount) {
+}

--- a/backend/order/src/main/java/org/samtuap/inong/domain/delivery/repository/DeliveryRepository.java
+++ b/backend/order/src/main/java/org/samtuap/inong/domain/delivery/repository/DeliveryRepository.java
@@ -26,5 +26,7 @@ public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
         return findById(id).orElseThrow(()->new BaseCustomException(DELIVERY_NOT_FOUND));
     }
 
-    Page<Delivery> findByDeliveryStatusIn(List<DeliveryStatus> statuses, Pageable pageable);
+    Page<Delivery> findByOrderingInAndDeliveryStatusIn(List<Ordering> orderList,
+                                                       List<DeliveryStatus> statuses,
+                                                       Pageable pageable);
 }

--- a/backend/order/src/main/java/org/samtuap/inong/domain/delivery/repository/DeliveryRepository.java
+++ b/backend/order/src/main/java/org/samtuap/inong/domain/delivery/repository/DeliveryRepository.java
@@ -3,13 +3,13 @@ package org.samtuap.inong.domain.delivery.repository;
 import org.samtuap.inong.common.exception.BaseCustomException;
 import org.samtuap.inong.domain.delivery.entity.Delivery;
 import org.samtuap.inong.domain.delivery.entity.DeliveryStatus;
+import org.samtuap.inong.domain.order.entity.Ordering;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.samtuap.inong.common.exceptionType.DeliveryExceptionType.DELIVERY_NOT_FOUND;
@@ -17,9 +17,10 @@ import static org.samtuap.inong.common.exceptionType.DeliveryExceptionType.DELIV
 @Repository
 public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
 
-    Page<Delivery> findByDeliveryStatusAndDeliveryDueDateBefore(DeliveryStatus deliveryStatus,
-                                                                LocalDate endDate,
-                                                                Pageable pageable);
+    Page<Delivery> findByOrderingInAndDeliveryStatusAndDeliveryDueDateBefore(List<Ordering> orderList,
+                                                                             DeliveryStatus deliveryStatus,
+                                                                             LocalDate endDate,
+                                                                             Pageable pageable);
 
     default Delivery findByIdOrThrow(Long id) {
         return findById(id).orElseThrow(()->new BaseCustomException(DELIVERY_NOT_FOUND));

--- a/backend/order/src/main/java/org/samtuap/inong/domain/delivery/service/DeliveryService.java
+++ b/backend/order/src/main/java/org/samtuap/inong/domain/delivery/service/DeliveryService.java
@@ -67,11 +67,14 @@ public class DeliveryService {
     /**
      * 사장님 페이지 > 처리한 배송 조회
      */
-    public Page<DeliveryCompletedListResponse> completedDelivery(Pageable pageable) {
+    public Page<DeliveryCompletedListResponse> completedDelivery(Long sellerId, Pageable pageable) {
+        // 사장이 내농장 찾아옴
+        FarmDetailGetResponse farm = productFeign.getFarmInfoWithSeller(sellerId);
+        List<Ordering> orderingList = orderRepository.findByFarmId(farm.id());
 
         // IN_DELIVERY, AFTER_DELIVERY인 배송건 가져오기
         List<DeliveryStatus> statuses = List.of(DeliveryStatus.IN_DELIVERY, DeliveryStatus.AFTER_DELIVERY);
-        Page<Delivery> deliveries = deliveryRepository.findByDeliveryStatusIn(statuses, pageable);
+        Page<Delivery> deliveries = deliveryRepository.findByOrderingInAndDeliveryStatusIn(orderingList, statuses, pageable);
 
         return deliveries.map(delivery -> {
             MemberDetailResponse member = memberFeign.getMemberById(delivery.getOrdering().getMemberId());

--- a/backend/order/src/main/java/org/samtuap/inong/domain/order/repository/OrderRepository.java
+++ b/backend/order/src/main/java/org/samtuap/inong/domain/order/repository/OrderRepository.java
@@ -15,4 +15,6 @@ public interface OrderRepository extends JpaRepository<Ordering, Long> {
             "ORDER BY COUNT(o.packageId) DESC")
     List<Long> findTop10PackageIdWithMostOrders();
 
+    List<Ordering> findByFarmId(Long farm);
+
 }

--- a/backend/product/src/main/java/org/samtuap/inong/domain/farm/api/FarmController.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/farm/api/FarmController.java
@@ -63,4 +63,13 @@ public class FarmController {
 
 
     }
+
+    /**
+     * feign 요청용 (sellerId로 입력받음)
+     * sellerId에 해당하는 사장님의 '농장' 정보 반환
+     */
+    @GetMapping("/seller/{sellerId}")
+    public FarmDetailGetResponse getFarmInfoWithSeller(@PathVariable("sellerId") Long sellerId) {
+        return farmService.getFarmInfoWithSeller(sellerId);
+    }
 }

--- a/backend/product/src/main/java/org/samtuap/inong/domain/farm/repository/FarmRepository.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/farm/repository/FarmRepository.java
@@ -13,6 +13,7 @@ import org.springframework.data.jpa.repository.Query;
 import java.util.List;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.samtuap.inong.common.exceptionType.ProductExceptionType.FARM_NOT_FOUND;
 
@@ -21,8 +22,10 @@ public interface FarmRepository extends JpaRepository<Farm, Long> {
         return findById(farmId).orElseThrow(() -> new BaseCustomException(FARM_NOT_FOUND));
     }
 
+    Optional<Farm> findBySellerId(Long sellerId);
+
     default Farm findBySellerIdOrThrow(Long sellerId) {
-        return findById(sellerId).orElseThrow(() -> new BaseCustomException(FARM_NOT_FOUND));
+        return findBySellerId(sellerId).orElseThrow(() -> new BaseCustomException(FARM_NOT_FOUND));
     }
 
     Page<Farm> findAll(Specification<Farm> specification, Pageable pageable);

--- a/backend/product/src/main/java/org/samtuap/inong/domain/farm/service/FarmService.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/farm/service/FarmService.java
@@ -96,5 +96,13 @@ public class FarmService {
                 })
                 .toList();
     }
+
+    /**
+     * feign 요청용 (sellerId로 입력받음)
+     */
+    public FarmDetailGetResponse getFarmInfoWithSeller(Long sellerId) {
+        Farm farm = farmRepository.findBySellerIdOrThrow(sellerId);
+        return FarmDetailGetResponse.fromEntity(farm);
+    }
   
 }


### PR DESCRIPTION
## 📌 PR 타입
<!-- [x] 이렇게하면 체크돼요 -->
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 리팩토링
- [ ] docs 작업


## 📄 작업 내용
<!-- ex) 구글 소셜 로그인 기능추가, 프로젝트 모집글 쓰기 API 작성 -->
- 다가오는 배송 조회 시 sellerId 활용해서 처리
- 처리된 배송 조회 시 sellerId 활용해서 처리



## 📷 결과 화면
<!-- 포스트맨 실행결과를 캡처해주세요 -->
**(1) 다가오는 배송 조회** <br>
조건 ) 현재 로그인 된 판매자가 볼 수 있는 배송건은 ordering_id가 1, 3임 <br>

즉 ordering_id 1, 3번을 출력하는데, 이 때 1번에서 2개는 처리됐고, id=3, id=10은 아직 날짜가 되지 않았기 때문에 남은 ordeing_id=3인 4개의 배송건만 출력되면 됨 
<img src="https://github.com/user-attachments/assets/e8bd553c-d500-4462-ace8-6470a6c4a6a4" width=600>
<img src="https://github.com/user-attachments/assets/02d3bb7a-e8b7-4802-81ea-47c1dd309d97" width=600>

<br><br>

**(2) 처리된 배송 조회**<br>
마찬가지로 현재 로그인 된 판매자가 볼 수 있는 건 ordering_id= 1, 3임<br>

그 중 delivery_at이 추가된 (=배송된) id=1, 2인 데이터가 출력되어야 함<br>
<img src="https://github.com/user-attachments/assets/9c991d93-cf6f-4e25-89b1-bec4eb86c9c5" width=600>
<img src="https://github.com/user-attachments/assets/b958ba24-6dec-42f5-b709-39c2b0dbe0de" width=600>

<br><br>
+) 만약 id=2 배달건의 ordering_id=2로 변경하여, 현재 로그인 한 판매자의 배송건이 아니라고 가정하면 ⇒ 출력이 되면 안됨 <br>
<img src="https://github.com/user-attachments/assets/c14962da-2252-4882-b1de-1727f9106a6e" width=600>
<img src="https://github.com/user-attachments/assets/3c67f261-1df6-4e07-8fe3-14943b084cd0" width=600>
<br>id=1인 배송건만 걸러져서 잘 출력됨 


## ✔️ 기타 사항
<!-- 리뷰 받고 싶은 포인트를 적어주세요! -->

## 🌳 작업 브랜치
<!--ex)  feat/IS-1  -->
closed #109 