### PR TITLE
chore: 공지사항 sellerId오류처리 추가

### DIFF
--- a/backend/product/src/main/java/org/samtuap/inong/domain/farmNotice/api/FarmNoticeController.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/farmNotice/api/FarmNoticeController.java
@@ -81,8 +81,9 @@ public class FarmNoticeController {
      */
     @PostMapping("/{farm_id}/notice/create")
     public void createNotice(@PathVariable("farm_id") Long farmId,
+                             @RequestHeader("sellerId") Long sellerId,
                              @RequestBody NoticeCreateRequest dto) {
-        farmNoticeService.createNotice(farmId, dto);
+        farmNoticeService.createNotice(farmId, sellerId, dto);
     }
 
     /**
@@ -91,8 +92,9 @@ public class FarmNoticeController {
     @PutMapping("/{farm_id}/notice/{notice_id}/update")
     public void updateNotice(@PathVariable("farm_id") Long farmId,
                              @PathVariable("notice_id") Long noticeId,
+                             @RequestHeader("sellerId") Long sellerId,
                              @RequestBody NoticeUpdateRequest dto) {
-        farmNoticeService.updateNotice(farmId, noticeId, dto);
+        farmNoticeService.updateNotice(farmId, noticeId, sellerId, dto);
     }
 
     /**
@@ -100,8 +102,9 @@ public class FarmNoticeController {
      */
     @DeleteMapping("/{farm_id}/notice/{notice_id}/delete")
     public void deleteNotice(@PathVariable("farm_id") Long farmId,
-                             @PathVariable("notice_id") Long noticeId) {
-        farmNoticeService.deleteNotice(farmId, noticeId);
+                             @PathVariable("notice_id") Long noticeId,
+                             @RequestHeader("sellerId") Long sellerId) {
+        farmNoticeService.deleteNotice(farmId, noticeId, sellerId);
     }
 
 }


### PR DESCRIPTION
## 📌 PR 타입
<!-- [x] 이렇게하면 체크돼요 -->
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 리팩토링
- [ ] docs 작업


## 📄 작업 내용
<!-- ex) 구글 소셜 로그인 기능추가, 프로젝트 모집글 쓰기 API 작성 -->
판매자가 공지사항을 등록할 떄, Farm엔티티에 있는 sellerId와 로그인한 판매자의 id와 다르면 에러처리

## 📷 결과 화면
<!-- 포스트맨 실행결과를 캡처해주세요 -->

## ✔️ 기타 사항
<!-- 리뷰 받고 싶은 포인트를 적어주세요! -->

## 🌳 작업 브랜치
<!--ex)  feat/IS-1  -->
closed #127