### PR TITLE
chore: 로그인 시 Role 데이터 반환 추가

### DIFF
--- a/backend/member/src/main/java/org/samtuap/inong/domain/member/dto/SignInResponse.java
+++ b/backend/member/src/main/java/org/samtuap/inong/domain/member/dto/SignInResponse.java
@@ -2,6 +2,7 @@ package org.samtuap.inong.domain.member.dto;
 
 import lombok.Builder;
 import org.samtuap.inong.domain.member.entity.Member;
+import org.samtuap.inong.domain.member.entity.MemberRole;
 import org.samtuap.inong.domain.member.entity.SocialType;
 import org.samtuap.inong.domain.member.jwt.domain.JwtToken;
 
@@ -11,6 +12,7 @@ public record SignInResponse(Long memberId,
                              String email,
                              String socialId,
                              SocialType socialType,
+                             String role,
                              String accessToken,
                              String refreshToken){
     public static SignInResponse fromEntity(Member member, JwtToken jwtToken){
@@ -20,6 +22,7 @@ public record SignInResponse(Long memberId,
                 .email(member.getEmail())
                 .socialType(member.getSocialType())
                 .socialId(member.getSocialId())
+                .role(MemberRole.MEMBER.toString())
                 .accessToken(jwtToken.accessToken())
                 .refreshToken(jwtToken.refreshToken())
                 .build();

--- a/backend/member/src/main/java/org/samtuap/inong/domain/member/dto/SignUpResponse.java
+++ b/backend/member/src/main/java/org/samtuap/inong/domain/member/dto/SignUpResponse.java
@@ -1,23 +1,30 @@
 package org.samtuap.inong.domain.member.dto;
 
+import lombok.Builder;
 import org.samtuap.inong.domain.member.entity.Member;
+import org.samtuap.inong.domain.member.entity.MemberRole;
 import org.samtuap.inong.domain.member.entity.SocialType;
 import org.samtuap.inong.domain.member.jwt.domain.JwtToken;
 
+@Builder
 public record SignUpResponse(Long memberId,
                              String name,
                              String email,
                              String socialId,
                              SocialType socialType,
+                             String role,
                              String accessToken,
                              String refreshToken){
     public static SignUpResponse fromEntity(Member member, JwtToken jwtToken) {
-        return new SignUpResponse(member.getId(),
-                member.getName(),
-                member.getEmail(),
-                member.getSocialId(),
-                member.getSocialType(),
-                jwtToken.accessToken(),
-                jwtToken.refreshToken());
+        return SignUpResponse.builder()
+                .memberId(member.getId())
+                .name(member.getName())
+                .email(member.getEmail())
+                .socialId(member.getSocialId())
+                .socialType(member.getSocialType())
+                .role(MemberRole.MEMBER.toString())
+                .accessToken(jwtToken.accessToken())
+                .refreshToken(jwtToken.refreshToken())
+                .build();
     }
 }


### PR DESCRIPTION
## 📌 PR 타입
<!-- [x] 이렇게하면 체크돼요 -->
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 리팩토링
- [ ] docs 작업


## 📄 작업 내용
<!-- ex) 구글 소셜 로그인 기능추가, 프로젝트 모집글 쓰기 API 작성 -->
로그인 시 localStorage 에 Role 저장해주기 위해 반환값에 Role 추가
- 처음 로직 구현 시에는 Role 이 추가 되기 전이라 해당 설정이 없었던 것 같아 수정하겠습니다 !

## 📷 결과 화면
<!-- 포스트맨 실행결과를 캡처해주세요 -->
<img width="502" alt="스크린샷 2024-09-29 오후 1 28 34" src="https://github.com/user-attachments/assets/23fb5c3a-3670-4a35-8d71-cd88c275b7bd">

## ✔️ 기타 사항
<!-- 리뷰 받고 싶은 포인트를 적어주세요! -->
`.role(MemberRole.MEMBER.toString())`
소셜 로그인을 이용하는 경우는 반드시 Member 인 경우밖에 없어서,
위와 같이 코드를 추가했는데 다른 방법으로 role 을 가져오는게 맞는건지.... 확인 부탁드립니다.....
## 🌳 작업 브랜치
<!--ex)  feat/IS-1  -->
closed #171 