### PR TITLE
chore: 공지사항 목록에 해당 글에 대한 댓글 수 반환

### DIFF
--- a/backend/product/src/main/java/org/samtuap/inong/domain/farmNotice/dto/NoticeListResponse.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/farmNotice/dto/NoticeListResponse.java
@@ -11,10 +11,11 @@ public record NoticeListResponse(
         Long id,
         String title,
         String content,
-        List<String> noticeImages
+        List<String> noticeImages,
+        Long commentCnt // 해동 공지사항의 댓글 수
 ) {
 
-    public static NoticeListResponse from(FarmNotice notice, List<FarmNoticeImage> noticeImages) {
+    public static NoticeListResponse from(FarmNotice notice, List<FarmNoticeImage> noticeImages, Long commentCnt) {
 
         List<String> imageUrls = noticeImages.stream()
                 .map(FarmNoticeImage::getImageUrl)
@@ -25,6 +26,7 @@ public record NoticeListResponse(
                 .title(notice.getTitle())
                 .content(notice.getContents())
                 .noticeImages(imageUrls)
+                .commentCnt(commentCnt)
                 .build();
     }
 }

--- a/backend/product/src/main/java/org/samtuap/inong/domain/farmNotice/service/FarmNoticeService.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/farmNotice/service/FarmNoticeService.java
@@ -51,8 +51,9 @@ public class FarmNoticeService {
 
         return noticeList.map(notice -> {
             List<FarmNoticeImage> noticeImages = farmNoticeImageRepository.findByFarmNotice(notice);
-            NoticeListResponse dto = NoticeListResponse.from(notice, noticeImages);
-            return NoticeListResponse.from(notice, noticeImages);
+            // 댓글 수 반환
+            Page<NoticeComment> commentList = noticeCommentRepository.findByFarmNotice(notice, pageable);
+            return NoticeListResponse.from(notice, noticeImages, commentList.getTotalElements());
         });
     }
 


### PR DESCRIPTION
## 📌 PR 타입
<!-- [x] 이렇게하면 체크돼요 -->
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 리팩토링
- [ ] docs 작업


## 📄 작업 내용
<!-- ex) 구글 소셜 로그인 기능추가, 프로젝트 모집글 쓰기 API 작성 -->
- 공지사항 목록에 해당 글에 대한 댓글 수 반환


## 📷 결과 화면
<!-- 포스트맨 실행결과를 캡처해주세요 -->
결과 화면은 client 쪽에 첨부하겠습니다 :) 

## ✔️ 기타 사항
<!-- 리뷰 받고 싶은 포인트를 적어주세요! -->

## 🌳 작업 브랜치
<!--ex)  feat/IS-1  -->
closed #173 