### PR TITLE
chore: 판매자 탈퇴 로직 수정

### DIFF
--- a/backend/product/src/main/java/org/samtuap/inong/common/exceptionType/SellerExceptionType.java
+++ b/backend/product/src/main/java/org/samtuap/inong/common/exceptionType/SellerExceptionType.java
@@ -6,7 +6,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum SellerExceptionType implements ExceptionType {
     EMAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 이메일을 찾을 수 없습니다."),
-    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 잘못되었습니다."),
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 잘못되었습니다."),
     EMAIL_ALREADY_REGISTERED(HttpStatus.BAD_REQUEST, "이미 등록된 이메일입니다."),
     PASSWORD_TOO_SHORT(HttpStatus.BAD_REQUEST, "비밀번호는 8자 이상이어야 합니다."),
     PACKAGES_EXIST(HttpStatus.BAD_REQUEST, "패키지가 남아 있어 탈퇴할 수 없습니다."),

--- a/backend/product/src/main/java/org/samtuap/inong/domain/seller/api/SellerController.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/seller/api/SellerController.java
@@ -10,7 +10,6 @@ import org.samtuap.inong.domain.seller.dto.*;
 import org.samtuap.inong.domain.seller.entity.SellerRole;
 import org.samtuap.inong.domain.seller.jwt.domain.JwtToken;
 import org.samtuap.inong.domain.seller.jwt.service.JwtService;
-import org.samtuap.inong.domain.seller.securities.JwtProvider;
 import org.samtuap.inong.domain.seller.service.MailService;
 import org.samtuap.inong.domain.seller.service.SellerService;
 import org.springframework.data.domain.Page;

--- a/backend/product/src/main/java/org/samtuap/inong/domain/seller/api/SellerController.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/seller/api/SellerController.java
@@ -60,8 +60,9 @@ public class SellerController {
     }
 
     @DeleteMapping("/withdraw")
-    public ResponseEntity<?> withDraw(@RequestBody Long sellerId) {
-        sellerService.withDraw(sellerId);
+    public ResponseEntity<?> withDraw(@RequestHeader("sellerId") Long sellerId,
+                                      @RequestBody String password) {
+        sellerService.withDraw(sellerId, password);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 

--- a/backend/product/src/main/java/org/samtuap/inong/domain/seller/dto/SellerSignInResponse.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/seller/dto/SellerSignInResponse.java
@@ -1,18 +1,25 @@
 package org.samtuap.inong.domain.seller.dto;
 
+import lombok.Builder;
+import org.samtuap.inong.domain.seller.entity.SellerRole;
 import org.samtuap.inong.domain.seller.jwt.domain.JwtToken;
 import org.samtuap.inong.domain.seller.entity.Seller;
 
+@Builder
 public record SellerSignInResponse(Long sellerId,
                                    String name,
                                    String email,
                                    String accessToken,
-                                   String refreshToken){
+                                   String refreshToken,
+                                   String role){
     public static SellerSignInResponse fromEntity(Seller seller, JwtToken jwtToken) {
-        return new SellerSignInResponse(seller.getId(),
-                seller.getName(),
-                seller.getEmail(),
-                jwtToken.accessToken(),
-                jwtToken.refreshToken());
+        return SellerSignInResponse.builder()
+                .sellerId(seller.getId())
+                .name(seller.getName())
+                .email(seller.getEmail())
+                .accessToken(jwtToken.accessToken())
+                .refreshToken(jwtToken.refreshToken())
+                .role(SellerRole.SELLER.toString())
+                .build();
     }
 }


### PR DESCRIPTION
## 📌 PR 타입
<!-- [x] 이렇게하면 체크돼요 -->
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 리팩토링
- [ ] docs 작업


## 📄 작업 내용
- 판매자 탈퇴 시 비밀번호를 입력받아 검증하는 과정을 추가 했습니다.
- 기존엔 Farm을 찾을 때 Farm이 없으면 에러가 나게 되어있었는데, Farm이 존재하는 판매자에 한해서 상품을 검증하도록
로직을 수정했습니다.



## 📷 결과 화면
- 탈퇴 완료
![탈퇴 완료](https://github.com/user-attachments/assets/51443a0b-b327-4cd7-b420-a06bfcd7935e)

- 비밀번호 불일치
![비밀번호 불일치](https://github.com/user-attachments/assets/fcf062d0-a1a8-4318-92f6-3e10734ab885)

- 패키지가 남아있을 때
![패키지가 남아있음](https://github.com/user-attachments/assets/015424b3-09d3-4739-98e1-82623e19b004)

- DB
![DB](https://github.com/user-attachments/assets/2050ef71-5c53-40aa-b442-ceb1ec72d47e)

## ✔️ 기타 사항


## 🌳 작업 브랜치
closed #185 