### PR TITLE
fix: 클라이언트 요청 시 memberId 헤더로 처리

### DIFF
--- a/backend/member/src/main/java/org/samtuap/inong/domain/member/api/MemberController.java
+++ b/backend/member/src/main/java/org/samtuap/inong/domain/member/api/MemberController.java
@@ -48,13 +48,13 @@ public class MemberController {
     }
 
     @DeleteMapping("/withdraw")
-    public ResponseEntity<?> withDraw(@RequestBody Long memberId){
+    public ResponseEntity<?> withDraw(@RequestHeader("myId") Long memberId){
         memberService.withdraw(memberId);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
     @GetMapping("/member-info")
-    public ResponseEntity<MemberInfoResponse> getMemberInfo(@RequestBody Long memberId){
+    public ResponseEntity<MemberInfoResponse> getMemberInfo(@RequestHeader("myId") Long memberId){
         MemberInfoResponse memberInfo =  memberService.getMemberInfo(memberId);
         return new ResponseEntity<>(memberInfo, HttpStatus.OK);
     }


### PR DESCRIPTION
## 📌 PR 타입
<!-- [x] 이렇게하면 체크돼요 -->
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 리팩토링
- [ ] docs 작업


## 📄 작업 내용
<!-- ex) 구글 소셜 로그인 기능추가, 프로젝트 모집글 쓰기 API 작성 -->
- 클라이언트 요청 시 memberId 넘겨주는 부분 헤더로 처리
  - @RequestParam 등을 @RequestHeader 로 변경

## 📷 결과 화면
<!-- 포스트맨 실행결과를 캡처해주세요 -->

## ✔️ 기타 사항
<!-- 리뷰 받고 싶은 포인트를 적어주세요! -->

## 🌳 작업 브랜치
<!--ex)  feat/IS-1  -->
closed #187 