### PR TITLE
feat: 전체 카테고리 리스트 불러오기

### DIFF
--- a/backend/product/src/main/java/org/samtuap/inong/common/exceptionType/FarmExceptionType.java
+++ b/backend/product/src/main/java/org/samtuap/inong/common/exceptionType/FarmExceptionType.java
@@ -5,7 +5,8 @@ import org.springframework.http.HttpStatus;
 
 @RequiredArgsConstructor
 public enum FarmExceptionType implements ExceptionType {
-    FARM_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 카테고리 입니다.");
+    FARM_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 카테고리 입니다."),
+    FARM_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 농장이 존재합니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/backend/product/src/main/java/org/samtuap/inong/domain/farm/api/FarmController.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/farm/api/FarmController.java
@@ -95,4 +95,10 @@ public class FarmController {
         List<FarmCategoryResponse> categories = farmService.getAllFarmCategories();
         return new ResponseEntity<>(categories, HttpStatus.OK);
     }
+
+    @GetMapping("/exists")
+    public ResponseEntity<Boolean> checkFarmExists(@RequestHeader("sellerId") Long sellerId) {
+        boolean exists = farmService.checkFarmExistsBySellerId(sellerId);
+        return ResponseEntity.ok(exists);
+    }
 }

--- a/backend/product/src/main/java/org/samtuap/inong/domain/farm/api/FarmController.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/farm/api/FarmController.java
@@ -3,6 +3,7 @@ package org.samtuap.inong.domain.farm.api;
 import lombok.RequiredArgsConstructor;
 import org.samtuap.inong.domain.farm.dto.*;
 import org.samtuap.inong.domain.farm.service.FarmService;
+import org.samtuap.inong.domain.seller.dto.FarmCategoryResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -87,5 +88,11 @@ public class FarmController {
                                          @RequestHeader("sellerId") Long sellerId) {
         FarmCreateResponse response = farmService.createFarm(request, sellerId);
         return new ResponseEntity<>(response, HttpStatus.CREATED);
+    }
+
+    @GetMapping("/categories")
+    public ResponseEntity<List<FarmCategoryResponse>> getAllCategories() {
+        List<FarmCategoryResponse> categories = farmService.getAllFarmCategories();
+        return new ResponseEntity<>(categories, HttpStatus.OK);
     }
 }

--- a/backend/product/src/main/java/org/samtuap/inong/domain/farm/repository/FarmRepository.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/farm/repository/FarmRepository.java
@@ -34,4 +34,5 @@ public interface FarmRepository extends JpaRepository<Farm, Long> {
     String getFarmNameById(@Param("farmId") Long farmId);
 
 
+    boolean existsBySellerId(Long sellerId);
 }

--- a/backend/product/src/main/java/org/samtuap/inong/domain/farm/service/FarmService.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/farm/service/FarmService.java
@@ -161,4 +161,8 @@ public class FarmService {
         }
         return categoryResponses;
     }
+
+    public boolean checkFarmExistsBySellerId(Long sellerId) {
+        return farmRepository.existsBySellerId(sellerId);
+    }
 }

--- a/backend/product/src/main/java/org/samtuap/inong/domain/farm/service/FarmService.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/farm/service/FarmService.java
@@ -15,6 +15,7 @@ import org.samtuap.inong.domain.farm.entity.FarmCategoryRelation;
 import org.samtuap.inong.domain.farm.repository.FarmCategoryRelationRepository;
 import org.samtuap.inong.domain.farm.repository.FarmCategoryRepository;
 import org.samtuap.inong.domain.farm.repository.FarmRepository;
+import org.samtuap.inong.domain.seller.dto.FarmCategoryResponse;
 import org.samtuap.inong.search.document.FarmDocument;
 import org.samtuap.inong.search.service.FarmSearchService;
 import org.springframework.data.domain.Page;
@@ -27,6 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.samtuap.inong.common.exceptionType.FarmExceptionType.FARM_ALREADY_EXISTS;
 import static org.samtuap.inong.common.exceptionType.FarmExceptionType.FARM_CATEGORY_NOT_FOUND;
 
 @RequiredArgsConstructor
@@ -126,6 +128,11 @@ public class FarmService {
 
     @Transactional
     public FarmCreateResponse createFarm(FarmCreateRequest request, Long sellerId) {
+
+        if (farmRepository.existsBySellerId(sellerId)) {
+            throw new BaseCustomException(FARM_ALREADY_EXISTS);
+        }
+
         Farm farm = FarmCreateRequest.toEntity(request, sellerId);
         farm = farmRepository.save(farm);
 
@@ -144,5 +151,14 @@ public class FarmService {
         farmSearchService.indexFarmDocument(farmDocument);
 
         return FarmCreateResponse.fromEntity(farm);
+    }
+
+    public List<FarmCategoryResponse> getAllFarmCategories() {
+        List<FarmCategory> categories = farmCategoryRepository.findAll();
+        List<FarmCategoryResponse> categoryResponses = new ArrayList<>();
+        for (FarmCategory category : categories) {
+            categoryResponses.add(FarmCategoryResponse.fromEntity(category));
+        }
+        return categoryResponses;
     }
 }

--- a/backend/product/src/main/java/org/samtuap/inong/domain/seller/dto/FarmCategoryResponse.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/seller/dto/FarmCategoryResponse.java
@@ -1,0 +1,18 @@
+package org.samtuap.inong.domain.seller.dto;
+
+import lombok.Builder;
+import org.samtuap.inong.domain.farm.entity.FarmCategory;
+
+@Builder
+public record FarmCategoryResponse(
+        Long id,
+        String title
+) {
+
+    public static FarmCategoryResponse fromEntity(FarmCategory farmCategory) {
+        return FarmCategoryResponse.builder()
+                .id(farmCategory.getId())
+                .title(farmCategory.getTitle())
+                .build();
+    }
+}


### PR DESCRIPTION
## 📌 PR 타입
<!-- [x] 이렇게하면 체크돼요 -->
- [x] 기능 추가
- [x] 기능 수정
- [ ] 리팩토링
- [ ] docs 작업


## 📄 작업 내용
- 전체 카테고리를 불러오는 api 추가
- 이미 농장을 생성한 사용자는 농장 생성 불가

## 📷 결과 화면
- 전체 카테고리 리스트
![전체 카테고리 리스트](https://github.com/user-attachments/assets/7c18fe7b-950b-4971-ae0d-4bd4e27f421e)

- 이미 농장을 생성한 사용자
![이미 농장을 가지고 있는 판매자](https://github.com/user-attachments/assets/9c263cb6-6261-4039-a79e-0a5b7a746c72)


## ✔️ 기타 사항

## 🌳 작업 브랜치
closed #191 