### PR TITLE
chore: liveId를 sessionId로 변경 및 즐겨찾기 농장 시청인원 표시

### DIFF
--- a/backend/live/src/main/java/org/samtuap/inong/domain/chat/api/ChatController.java
+++ b/backend/live/src/main/java/org/samtuap/inong/domain/chat/api/ChatController.java
@@ -16,9 +16,9 @@ public class ChatController {
 
     private final ChatService chatService;
 
-    @MessageMapping("/chat/{liveId}/sendMessage")
-    public void sendMessage(@DestinationVariable ("liveId") String liveId,
+    @MessageMapping("/chat/{sessionId}/sendMessage")
+    public void sendMessage(@DestinationVariable ("sessionId") String sessionId,
                             @Payload ChatMessageRequest messageRequest) {
-        chatService.processAndSendMessage(liveId, messageRequest);
+        chatService.processAndSendMessage(sessionId, messageRequest);
     }
 }

--- a/backend/live/src/main/java/org/samtuap/inong/domain/chat/dto/ChatMessageRequest.java
+++ b/backend/live/src/main/java/org/samtuap/inong/domain/chat/dto/ChatMessageRequest.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 public record ChatMessageRequest(
         Long memberId,
         Long sellerId,
-        String liveId,
+        String sessionId,
         String name,
         String content,
         boolean isOwner,

--- a/backend/live/src/main/java/org/samtuap/inong/domain/chat/kafka/KafkaMessageListener.java
+++ b/backend/live/src/main/java/org/samtuap/inong/domain/chat/kafka/KafkaMessageListener.java
@@ -18,6 +18,6 @@ public class KafkaMessageListener {
     @KafkaListener(topics = KafkaConstants.KAFKA_TOPIC, groupId = "chat")
     public void listen(@Payload ChatMessageRequest message) {
         log.info("Received message from Kafka: {}", message);
-        simpMessagingTemplate.convertAndSend("/topic/live/" + message.liveId(), message);
+        simpMessagingTemplate.convertAndSend("/topic/live/" + message.sessionId(), message);
     }
 }

--- a/backend/live/src/main/java/org/samtuap/inong/domain/chat/service/ChatService.java
+++ b/backend/live/src/main/java/org/samtuap/inong/domain/chat/service/ChatService.java
@@ -24,7 +24,7 @@ public class ChatService {
     private final FarmFeign farmFeign;
     private final LiveRepository liveRepository;
 
-    public void processAndSendMessage(String liveId, ChatMessageRequest messageRequest) {
+    public void processAndSendMessage(String sessionId, ChatMessageRequest messageRequest) {
         Long memberId = messageRequest.memberId();
         Long sellerId = messageRequest.sellerId();
 
@@ -34,13 +34,13 @@ public class ChatService {
 
         // 개설자인지 여부 확인
         try {
-            Live live = liveRepository.findBySessionId(liveId)
-                    .orElseThrow(() -> new IllegalArgumentException("Live not found for id: " + liveId));
+            Live live = liveRepository.findBySessionId(sessionId)
+                    .orElseThrow(() -> new IllegalArgumentException("Live not found for id: " + sessionId));
             if (live.getOwnerId().equals(sellerId)) {
                 isOwner = true;
             }
         } catch (Exception e) {
-            log.error("Error fetching live info for liveId: {}", liveId, e);
+            log.error("Error fetching live info for sessionId: {}", sessionId, e);
         }
 
         log.info("Sending message with name: {}, isOwner: {}", senderName, isOwner);
@@ -81,7 +81,7 @@ public class ChatService {
         ChatMessageRequest updatedRequest = ChatMessageRequest.builder()
                 .memberId(memberId)
                 .sellerId(sellerId)
-                .liveId(liveId)
+                .sessionId(sessionId)
                 .name(senderName)  // 이름 설정 (멤버 이름 또는 농장 이름)
                 .content(messageRequest.content())
                 .type(messageRequest.type())

--- a/backend/member/src/main/java/org/samtuap/inong/domain/favorites/dto/FavoritesLiveListResponse.java
+++ b/backend/member/src/main/java/org/samtuap/inong/domain/favorites/dto/FavoritesLiveListResponse.java
@@ -5,6 +5,7 @@ public record FavoritesLiveListResponse(
         Long farmId,
         String farmName,
         String title,
-        String liveImage
+        String liveImage,
+        int participantCount
 ) {
 }

--- a/backend/product/src/main/java/org/samtuap/inong/domain/farm/dto/FavoritesLiveListResponse.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/farm/dto/FavoritesLiveListResponse.java
@@ -5,6 +5,7 @@ public record FavoritesLiveListResponse(
         Long farmId,
         String farmName,
         String title,
-        String liveImage
+        String liveImage,
+        int participantCount
 ) {
 }

--- a/backend/product/src/main/java/org/samtuap/inong/domain/farm/service/FarmService.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/farm/service/FarmService.java
@@ -104,7 +104,8 @@ public class FarmService {
                             response.farmId(),
                             farmName,
                             response.title(),
-                            response.liveImage()
+                            response.liveImage(),
+                            response.participantCount()
                     );
                 })
                 .toList();

--- a/backend/product/src/main/java/org/samtuap/inong/domain/farm/service/FarmService.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/farm/service/FarmService.java
@@ -17,7 +17,6 @@ import org.samtuap.inong.domain.farm.repository.FarmCategoryRepository;
 import org.samtuap.inong.domain.farm.repository.FarmRepository;
 import org.samtuap.inong.domain.seller.dto.FarmCategoryResponse;
 import org.samtuap.inong.domain.seller.dto.SellerFarmInfoUpdateRequest;
-import org.samtuap.inong.domain.seller.entity.Seller;
 import org.samtuap.inong.search.document.FarmDocument;
 import org.samtuap.inong.search.service.FarmSearchService;
 import org.springframework.data.domain.Page;


### PR DESCRIPTION
## 📌 PR 타입
<!-- [x] 이렇게하면 체크돼요 -->
- [x] 기능 추가
- [x] 기능 수정
- [ ] 리팩토링
- [ ] docs 작업


## 📄 작업 내용
-  liveId를 sessionId로 변경
- 즐겨찾기 농장 시청 인원 표시


## 📷 결과 화면
- seller 시점 로그 표시
![찐 로그 수정](https://github.com/user-attachments/assets/da9e07d4-ef86-4434-a384-be30be08b5d3)

- 즐겨찾기 방송 리스트 시청 인원 표시
![즐겨찾기 방송 리스트 시청인원 표시](https://github.com/user-attachments/assets/d1e7e7bf-f038-43f6-84e5-a2f11036ac3d)



## ✔️ 기타 사항
<!-- 리뷰 받고 싶은 포인트를 적어주세요! -->

## 🌳 작업 브랜치
closed #223 