### PR TITLE
feat: 채팅 redis 추가

### DIFF
--- a/backend/live/src/main/java/org/samtuap/inong/common/exceptionType/ChatExceptionType.java
+++ b/backend/live/src/main/java/org/samtuap/inong/common/exceptionType/ChatExceptionType.java
@@ -10,7 +10,8 @@ public enum ChatExceptionType implements ExceptionType {
     AUTHORIZATION_HEADER_MISSING(HttpStatus.UNAUTHORIZED, "Authorization 헤더가 없거나 유효하지 않습니다."),
     INVALID_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 JWT 토큰입니다."),
     FARM_NOT_FOUND(HttpStatus.NOT_FOUND, "해당의 아이디 농장이이 존재하지 않습니다."),
-    IS_NOT_OWNER(HttpStatus.UNAUTHORIZED, "해당 사용자는 owner가 아닙니다.");
+    IS_NOT_OWNER(HttpStatus.UNAUTHORIZED, "해당 사용자는 owner가 아닙니다."),
+    ID_IS_NULL(HttpStatus.BAD_REQUEST, "id가 null 입니다.");
 
 
     private final HttpStatus status;

--- a/backend/live/src/main/java/org/samtuap/inong/config/RedisConfig.java
+++ b/backend/live/src/main/java/org/samtuap/inong/config/RedisConfig.java
@@ -1,0 +1,24 @@
+package org.samtuap.inong.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+        template.afterPropertiesSet();
+        return template;
+    }
+}

--- a/backend/live/src/main/java/org/samtuap/inong/domain/chat/api/ChatController.java
+++ b/backend/live/src/main/java/org/samtuap/inong/domain/chat/api/ChatController.java
@@ -24,11 +24,15 @@ public class ChatController {
         chatService.processAndSendMessage(sessionId, messageRequest);
     }
 
-    @PostMapping("/{sessionId}/kick/{memberId}")
+    @PostMapping("/{sessionId}/kick/{userId}")
     public ResponseEntity<String> kickUser(@PathVariable String sessionId,
-                                           @PathVariable Long memberId,
-                                           @RequestHeader("sellerId") Long sellerId) {
-        chatService.kickUser(sessionId, memberId, sellerId);
+                                           @PathVariable Long userId,
+                                           @RequestHeader("sellerId") Long requestSellerId) {
+        if (userId == null) {
+            return ResponseEntity.badRequest().body("ID : null");
+        }
+        log.info("강퇴 요청: sessionId = {}, userId = {}, requestSellerId = {}", sessionId, userId, requestSellerId);
+        chatService.kickUser(sessionId, userId, requestSellerId);
         return ResponseEntity.ok("사용자가 강퇴되었습니다.");
     }
 

--- a/backend/live/src/main/java/org/samtuap/inong/domain/chat/service/ChatService.java
+++ b/backend/live/src/main/java/org/samtuap/inong/domain/chat/service/ChatService.java
@@ -12,14 +12,12 @@ import org.samtuap.inong.domain.chat.kafka.KafkaConstants;
 import org.samtuap.inong.domain.live.dto.FarmDetailGetResponse;
 import org.samtuap.inong.domain.live.entity.Live;
 import org.samtuap.inong.domain.live.repository.LiveRepository;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 
-import java.util.HashSet;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-
+import static org.samtuap.inong.common.exceptionType.ChatExceptionType.ID_IS_NULL;
 import static org.samtuap.inong.common.exceptionType.ChatExceptionType.IS_NOT_OWNER;
 import static org.samtuap.inong.common.exceptionType.LiveExceptionType.LIVE_NOT_FOUND;
 
@@ -32,8 +30,10 @@ public class ChatService {
     private final MemberFeign memberFeign;
     private final FarmFeign farmFeign;
     private final LiveRepository liveRepository;
-    private final ConcurrentHashMap<String, Set<Long>> kickedUsersMap = new ConcurrentHashMap<>();
+    private final RedisTemplate<String, Object> redisTemplate;
     private final SimpMessagingTemplate messagingTemplate;
+
+    private static final String KICKED_USERS_KEY_PREFIX = "kicked:users:";
 
     public void processAndSendMessage(String sessionId, ChatMessageRequest messageRequest) {
         Long memberId = messageRequest.memberId();
@@ -44,8 +44,9 @@ public class ChatService {
         boolean isOwner = false;
 
         // 사용자가 강퇴된 상태인지 확인
-        if (isUserKicked(sessionId, memberId)) {
-            log.info("강퇴된 사용자 메시지 차단: sessionId = {}, memberId = {}", sessionId, memberId);
+        if ((memberId != null && isUserKicked(sessionId, memberId)) ||
+                (sellerId != null && isUserKicked(sessionId, sellerId))) {
+            log.info("강퇴된 사용자 메시지 차단: sessionId = {}, memberId = {}, sellerId = {}", sessionId, memberId, sellerId);
             return;
         }
 
@@ -108,18 +109,36 @@ public class ChatService {
         kafkaTemplate.send(KafkaConstants.KAFKA_TOPIC, updatedRequest);
     }
 
-    public void kickUser(String sessionId, Long memberId, Long sellerId) {
+    public void kickUser(String sessionId, Long userId, Long requestSellerId) {
         // 개설자인지 확인 (liveId로 소유자 확인 로직 추가 가능)
-        if (!isOwner(sessionId, sellerId)) {
+        if (!isOwner(sessionId, requestSellerId)) {
             throw new BaseCustomException(IS_NOT_OWNER);
         }
 
-        // 강퇴된 사용자 추가
-        kickedUsersMap.computeIfAbsent(sessionId, k -> new HashSet<>()).add(memberId);
-        log.info("사용자 강퇴됨: sessionId = {}, memberId = {}", sessionId, memberId);
+        if (userId == null) {
+            throw new BaseCustomException(ID_IS_NULL);
+        }
 
-        // 강퇴된 사용자에게 강퇴 메시지 전송
-        messagingTemplate.convertAndSend("/topic/kick/" + memberId, new KickMessage(memberId, "강퇴되었습니다."));
+        boolean isMember = isMember(userId);
+        // 강퇴된 사용자 추가 (Redis Set 사용)
+        String key = KICKED_USERS_KEY_PREFIX + sessionId;
+
+        if (isMember) {
+            redisTemplate.opsForSet().add(key, userId);
+            log.info("멤버 강퇴됨: sessionId = {}, memberId = {}", sessionId, userId);
+            messagingTemplate.convertAndSend("/topic/kick/" + userId, new KickMessage(userId, "강퇴되었습니다."));
+        } else {
+            redisTemplate.opsForSet().add(key, userId);
+            log.info("판매자 강퇴됨: sessionId = {}, sellerId = {}", sessionId, userId);
+            messagingTemplate.convertAndSend("/topic/kick/" + userId, new KickMessage(userId, "강퇴되었습니다."));
+        }
+
+        String participantKey = "live:participants:" + sessionId;
+        redisTemplate.opsForValue().decrement(participantKey);
+        Long currentParticipants = (Long) redisTemplate.opsForValue().get(participantKey);
+        log.info("현재 참여자 수: sessionId = {}, 참가자 수 = {}", sessionId, currentParticipants);
+        messagingTemplate.convertAndSend("/topic/live/" + sessionId + "/participants", currentParticipants);
+
     }
 
     private boolean isOwner(String sessionId, Long sellerId) {
@@ -136,7 +155,19 @@ public class ChatService {
     }
 
     // 강퇴된 사용자의 접속을 차단하기 위한 메서드
-    public boolean isUserKicked(String sessionId, Long memberId) {
-        return kickedUsersMap.containsKey(sessionId) && kickedUsersMap.get(sessionId).contains(memberId);
+    public boolean isUserKicked(String sessionId, Long userId) {
+        String key = KICKED_USERS_KEY_PREFIX + sessionId;
+        Boolean isMemberKicked = redisTemplate.opsForSet().isMember(key, userId);
+        return Boolean.TRUE.equals(isMemberKicked);
+    }
+
+    private boolean isMember(Long userId) {
+        // userId로 멤버 검증 로직 구현
+        try {
+            memberFeign.getMemberById(userId);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
     }
 }

--- a/backend/live/src/main/java/org/samtuap/inong/domain/chat/service/ChatService.java
+++ b/backend/live/src/main/java/org/samtuap/inong/domain/chat/service/ChatService.java
@@ -128,17 +128,6 @@ public class ChatService {
         log.info("{} 강퇴됨: sessionId = {}, userId = {}", userType, sessionId, userId);
 
         messagingTemplate.convertAndSend("/topic/kick/" + userId, new KickMessage(userId, "강퇴되었습니다."));
-
-        String participantKey = "live:participants:" + sessionId;
-        redisTemplate.opsForValue().decrement(participantKey);
-        Object countObj = redisTemplate.opsForValue().get(participantKey);
-        Long currentParticipants = 0L;
-        if (countObj instanceof Number) {
-            currentParticipants = ((Number) countObj).longValue();
-        }
-        log.info("현재 참여자 수: sessionId = {}, 참가자 수 = {}", sessionId, currentParticipants);
-        messagingTemplate.convertAndSend("/topic/live/" + sessionId + "/participants", currentParticipants);
-
     }
 
     private boolean isOwner(String sessionId, Long sellerId) {

--- a/backend/live/src/main/java/org/samtuap/inong/domain/chat/websocket/SocketController.java
+++ b/backend/live/src/main/java/org/samtuap/inong/domain/chat/websocket/SocketController.java
@@ -122,11 +122,7 @@ public class SocketController {
 
     public int getParticipantCount(String sessionId) {
         String key = LIVE_PARTICIPANTS_KEY_PREFIX + sessionId;
-        Object count = redisTemplate.opsForValue().get(key);
-        if (count instanceof Number) {
-            return ((Number) count).intValue();
-        } else {
-            return 0;
-        }
+        Integer count = (Integer) redisTemplate.opsForValue().get(key);
+        return (count != null) ? count : 0;
     }
 }

--- a/backend/live/src/main/java/org/samtuap/inong/domain/chat/websocket/SocketController.java
+++ b/backend/live/src/main/java/org/samtuap/inong/domain/chat/websocket/SocketController.java
@@ -82,6 +82,8 @@ public class SocketController {
             currentParticipants = ((Number) countObj).intValue();
         }
 
+        headerAccessor.getSessionAttributes().put("sessionId", sessionId);
+
         log.info("새로운 WebSocket 연결: sessionId = {}, 현재 참여자 수 = {}", sessionId, currentParticipants);
 
         // 실시간 참여자 수를 해당 채팅방으로 전송


### PR DESCRIPTION
## 📌 PR 타입
<!-- [x] 이렇게하면 체크돼요 -->
- [x] 기능 추가
- [x] 기능 수정
- [ ] 리팩토링
- [ ] docs 작업


## 📄 작업 내용
- 채팅 세션을 redis에서 관리하도록 수정
- 다른 판매자 강퇴 기능 추가


## 📷 결과 화면
- 라이브 세션 아이디
![생성한 라이브 세션 아이디](https://github.com/user-attachments/assets/8cd9f62f-5e67-483d-bd6a-13c652599d98)

- redis에 저장
![레디스에 저장](https://github.com/user-attachments/assets/451eb88e-6b08-4d3f-bd2a-bfd2162b73e5)

- 참여 인원 redis
![참여 인원 레디스](https://github.com/user-attachments/assets/0142d2b5-6e2b-4212-9efb-08924eb98750)

- 강퇴 인원 redis
![강퇴 후 레디스](https://github.com/user-attachments/assets/8873e5ae-4771-475d-a727-958591fd12c6)



## ✔️ 기타 사항
<!-- 리뷰 받고 싶은 포인트를 적어주세요! -->

## 🌳 작업 브랜치
closed #244 