### PR TITLE
chore: 라이브 & 채팅 반환 dto에 profile farmName, profileImage 추가

### DIFF
--- a/backend/live/src/main/java/org/samtuap/inong/domain/live/dto/FarmResponse.java
+++ b/backend/live/src/main/java/org/samtuap/inong/domain/live/dto/FarmResponse.java
@@ -2,6 +2,7 @@ package org.samtuap.inong.domain.live.dto;
 
 public record FarmResponse(
         Long id,
-        String farmName
+        String farmName,
+        String profileImageUrl
 ) {
 }

--- a/backend/live/src/main/java/org/samtuap/inong/domain/live/dto/LiveSessionResponse.java
+++ b/backend/live/src/main/java/org/samtuap/inong/domain/live/dto/LiveSessionResponse.java
@@ -10,25 +10,31 @@ public record LiveSessionResponse(
         String sessionId,
         String title,
         String liveImage,
-        boolean isLive
+        boolean isLive,
+        String farmName,
+        String profileImageUrl
 ) {
-    public static LiveSessionResponse fromEntity(LiveSessionRequest request, Live live, Session session) {
+    public static LiveSessionResponse fromEntity(LiveSessionRequest request, Live live, FarmDetailGetResponse farm, Session session) {
         return LiveSessionResponse.builder()
                 .liveId(live.getId())
                 .sessionId(session.getSessionId())
                 .title(request.title())
                 .liveImage(request.liveImage())
                 .isLive(true)
+                .farmName(farm.farmName())
+                .profileImageUrl(farm.profileImageUrl())
                 .build();
     }
 
-    public static LiveSessionResponse liveFromEntity(Live live) {
+    public static LiveSessionResponse liveFromEntity(Live live, FarmResponse farm) {
         return LiveSessionResponse.builder()
                 .liveId(live.getId())  // liveId
                 .sessionId(live.getSessionId())  // sessionId
                 .title(live.getTitle())  // Live 엔티티에서 title 가져오기
                 .liveImage(live.getLiveImage())  // liveImage 가져오기 (만약 존재한다면)
                 .isLive(true)  // 현재 라이브가 진행 중임을 표시
+                .farmName(farm.farmName())
+                .profileImageUrl(farm.profileImageUrl())
                 .build();
     }
 }

--- a/backend/live/src/main/java/org/samtuap/inong/domain/live/service/LiveService.java
+++ b/backend/live/src/main/java/org/samtuap/inong/domain/live/service/LiveService.java
@@ -85,7 +85,7 @@ public class LiveService {
         live.updateSessionId(session.getSessionId()); // sessionId를 라이브 시작하고 받아서 저장
         liveRepository.save(live);
 
-        return LiveSessionResponse.fromEntity(request, live, session);
+        return LiveSessionResponse.fromEntity(request, live, farm, session);
     }
 
     public LiveSessionResponse getSessionIdByLiveId(Long id) {
@@ -93,8 +93,9 @@ public class LiveService {
         if (live.getSessionId() == null) {
             throw new BaseCustomException(SESSION_NOT_FOUND);
         }
+        FarmResponse farm = farmFeign.getFarmById(live.getFarmId());
         log.info("{}로 session id 받자 : {}", id, live.getSessionId());
-        return LiveSessionResponse.liveFromEntity(live);  // 라이브의 세션 ID 반환
+        return LiveSessionResponse.liveFromEntity(live, farm);  // 라이브의 세션 ID 반환
     }
 
     /**


### PR DESCRIPTION
## 📌 PR 타입
<!-- [x] 이렇게하면 체크돼요 -->
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 리팩토링
- [ ] docs 작업


## 📄 작업 내용
<!-- ex) 구글 소셜 로그인 기능추가, 프로젝트 모집글 쓰기 API 작성 -->
- 라이브 & 채팅 반환 dto에 profile farmName, profileImage 추가


## 📷 결과 화면
<!-- 포스트맨 실행결과를 캡처해주세요 -->

## ✔️ 기타 사항
<!-- 리뷰 받고 싶은 포인트를 적어주세요! -->

## 🌳 작업 브랜치
<!--ex)  feat/IS-1  -->