### PR TITLE
fix: 주문시 Farm 엔티티의 주문수(orderCount)가 증가되도록 코드 추가

### DIFF
--- a/backend/order/src/main/java/org/samtuap/inong/domain/order/api/OrderController.java
+++ b/backend/order/src/main/java/org/samtuap/inong/domain/order/api/OrderController.java
@@ -42,7 +42,8 @@ public class OrderController {
     }
 
     @GetMapping("/list")
-    public ResponseEntity<Page<OrderPaymentListResponse>> getOrderPaymentList(@PageableDefault(size = 8,sort = {"createdAt"}, direction = Sort.Direction.DESC) Pageable pageable, @RequestHeader("myId") Long memberId){
+    public ResponseEntity<Page<OrderPaymentListResponse>> getOrderPaymentList(@PageableDefault(size = 8,sort = {"createdAt"}, direction = Sort.Direction.DESC) Pageable pageable,
+                                                                              @RequestHeader("myId") Long memberId){
         Page<OrderPaymentListResponse> myOrderPaymentList = orderService.getOrderPaymentList(pageable, memberId);
         return new ResponseEntity<>(myOrderPaymentList, HttpStatus.OK);
     }

--- a/backend/order/src/main/java/org/samtuap/inong/domain/order/dto/KafkaOrderCountIncreaseRequest.java
+++ b/backend/order/src/main/java/org/samtuap/inong/domain/order/dto/KafkaOrderCountIncreaseRequest.java
@@ -1,4 +1,0 @@
-package org.samtuap.inong.domain.order.dto;
-
-public record KafkaOrderCountIncreaseRequest(Long farmId) {
-}

--- a/backend/order/src/main/java/org/samtuap/inong/domain/order/dto/KafkaOrderCountIncreaseRequest.java
+++ b/backend/order/src/main/java/org/samtuap/inong/domain/order/dto/KafkaOrderCountIncreaseRequest.java
@@ -1,0 +1,4 @@
+package org.samtuap.inong.domain.order.dto;
+
+public record KafkaOrderCountIncreaseRequest(Long farmId) {
+}

--- a/backend/order/src/main/java/org/samtuap/inong/domain/order/dto/KafkaOrderCountUpdateRequest.java
+++ b/backend/order/src/main/java/org/samtuap/inong/domain/order/dto/KafkaOrderCountUpdateRequest.java
@@ -1,0 +1,7 @@
+package org.samtuap.inong.domain.order.dto;
+
+public record KafkaOrderCountUpdateRequest(Long farmId, OrderCountRequestType orderCountRequestType) {
+    public static enum OrderCountRequestType {
+        INCREASE, DECREASE;
+    }
+}

--- a/backend/order/src/main/java/org/samtuap/inong/domain/order/service/OrderService.java
+++ b/backend/order/src/main/java/org/samtuap/inong/domain/order/service/OrderService.java
@@ -38,6 +38,7 @@ import java.util.*;
 import static org.samtuap.inong.common.exceptionType.CouponExceptionType.*;
 import static org.samtuap.inong.common.exceptionType.OrderExceptionType.*;
 import static org.samtuap.inong.domain.delivery.entity.DeliveryStatus.BEFORE_DELIVERY;
+import static org.samtuap.inong.domain.order.dto.KafkaOrderCountUpdateRequest.OrderCountRequestType.INCREASE;
 import static org.samtuap.inong.domain.order.entity.CancelReason.SYSTEM_ERROR;
 
 @Slf4j
@@ -129,7 +130,8 @@ public class OrderService {
         makeReceipt(savedOrder, packageProduct, paidAmount, paymentId);
 
         // 6. orderCount 증가 이벤트 발행
-        kafkaTemplate.send("increase-order-count", new KafkaOrderCountIncreaseRequest(packageProduct.farmId()));
+        log.info("line 133 >>> 이벤트 발행");
+        kafkaTemplate.send("order-count-topic", new KafkaOrderCountUpdateRequest(packageProduct.farmId(), INCREASE));
 
         return PaymentResponse.builder()
                 .orderId(savedOrder.getId())

--- a/backend/order/src/main/java/org/samtuap/inong/domain/order/service/OrderService.java
+++ b/backend/order/src/main/java/org/samtuap/inong/domain/order/service/OrderService.java
@@ -130,7 +130,6 @@ public class OrderService {
         makeReceipt(savedOrder, packageProduct, paidAmount, paymentId);
 
         // 6. orderCount 증가 이벤트 발행
-        log.info("line 133 >>> 이벤트 발행");
         kafkaTemplate.send("order-count-topic", new KafkaOrderCountUpdateRequest(packageProduct.farmId(), INCREASE));
 
         return PaymentResponse.builder()

--- a/backend/product/src/main/java/org/samtuap/inong/common/exceptionType/FarmExceptionType.java
+++ b/backend/product/src/main/java/org/samtuap/inong/common/exceptionType/FarmExceptionType.java
@@ -6,7 +6,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum FarmExceptionType implements ExceptionType {
     FARM_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 카테고리 입니다."),
-    FARM_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 농장이 존재합니다.");
+    FARM_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 농장이 존재합니다."),
+    INVALID_ORDER_COUNT_REQUEST(HttpStatus.BAD_REQUEST, "주문 수 변경 요청이 올바르지 않습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/backend/product/src/main/java/org/samtuap/inong/config/KafkaConsumerConfig.java
+++ b/backend/product/src/main/java/org/samtuap/inong/config/KafkaConsumerConfig.java
@@ -1,0 +1,53 @@
+package org.samtuap.inong.config;
+
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.util.backoff.FixedBackOff;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@EnableKafka
+@Configuration
+public class KafkaConsumerConfig {
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Value("${spring.kafka.consumer.group-id}")
+    private String groupId;
+
+    @Value("${spring.kafka.consumer.auto-offset-reset}")
+    private String autoOffset;
+
+    @Bean
+    public ConsumerFactory<String, String> consumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG, groupId);
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, autoOffset);
+
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+
+        return new DefaultKafkaConsumerFactory<>(props);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        // 에러 핸들러: 에러가 발생하면 1초에 한번씩 요청 3번 다시 보냄
+        factory.setCommonErrorHandler(new DefaultErrorHandler(new FixedBackOff(1000L, 3)));
+
+        return factory;
+    }
+}

--- a/backend/product/src/main/java/org/samtuap/inong/domain/farm/dto/KafkaOrderCountUpdateRequest.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/farm/dto/KafkaOrderCountUpdateRequest.java
@@ -1,0 +1,7 @@
+package org.samtuap.inong.domain.farm.dto;
+
+public record KafkaOrderCountUpdateRequest(Long farmId, OrderCountRequestType orderCountRequestType) {
+    public static enum OrderCountRequestType {
+        INCREASE, DECREASE;
+    }
+}

--- a/backend/product/src/main/java/org/samtuap/inong/domain/farm/entity/Farm.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/farm/entity/Farm.java
@@ -56,4 +56,8 @@ public class Farm extends BaseEntity {
     public void updateFavoriteCount(Long favoriteCount) {
         this.favoriteCount = favoriteCount;
     }
+
+    public void updateOrderCount(Long orderCount) {
+        this.orderCount = orderCount;
+    }
 }

--- a/backend/product/src/main/java/org/samtuap/inong/domain/farm/service/FarmService.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/farm/service/FarmService.java
@@ -246,13 +246,10 @@ public class FarmService {
     @Transactional
     @KafkaListener(topics = "order-count-topic", groupId = "order-group", containerFactory = "kafkaListenerContainerFactory")
     public void consumeIssueNotification(String message /*listen 하면 스트링 형태로 메시지가 들어온다*/) {
-        log.info("line 248 >>>>> [Product Module] update order Count");
         ObjectMapper objectMapper = new ObjectMapper();
         try {
             KafkaOrderCountUpdateRequest request = objectMapper.readValue(message, KafkaOrderCountUpdateRequest.class);
             Farm farm = farmRepository.findByIdOrThrow(request.farmId());
-
-            log.info("line 254 >>>> {}", request);
 
             switch(request.orderCountRequestType()) {
                 case INCREASE -> farm.updateOrderCount(farm.getOrderCount() + 1);

--- a/backend/product/src/main/java/org/samtuap/inong/domain/farm/service/FarmService.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/farm/service/FarmService.java
@@ -1,5 +1,7 @@
 package org.samtuap.inong.domain.farm.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Predicate;
@@ -9,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.samtuap.inong.common.client.LiveFeign;
 import org.samtuap.inong.common.client.MemberFeign;
 import org.samtuap.inong.common.exception.BaseCustomException;
+import org.samtuap.inong.common.exceptionType.FarmExceptionType;
 import org.samtuap.inong.common.response.FavoriteGetResponse;
 import org.samtuap.inong.domain.farm.dto.*;
 import org.samtuap.inong.domain.farm.entity.Farm;
@@ -17,6 +20,7 @@ import org.samtuap.inong.domain.farm.entity.FarmCategoryRelation;
 import org.samtuap.inong.domain.farm.repository.FarmCategoryRelationRepository;
 import org.samtuap.inong.domain.farm.repository.FarmCategoryRepository;
 import org.samtuap.inong.domain.farm.repository.FarmRepository;
+import org.samtuap.inong.domain.notification.dto.KafkaNotificationRequest;
 import org.samtuap.inong.domain.seller.dto.FarmCategoryResponse;
 import org.samtuap.inong.domain.seller.dto.SellerFarmInfoUpdateRequest;
 import org.samtuap.inong.search.document.FarmDocument;
@@ -24,6 +28,7 @@ import org.samtuap.inong.search.service.FarmSearchService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,6 +38,8 @@ import java.util.stream.Collectors;
 
 import static org.samtuap.inong.common.exceptionType.FarmExceptionType.FARM_ALREADY_EXISTS;
 import static org.samtuap.inong.common.exceptionType.FarmExceptionType.FARM_CATEGORY_NOT_FOUND;
+import static org.samtuap.inong.common.exceptionType.NotificationExceptionType.FCM_SEND_FAIL;
+import static org.samtuap.inong.common.exceptionType.NotificationExceptionType.INVALID_FCM_REQUEST;
 
 @RequiredArgsConstructor
 @Service
@@ -232,6 +239,31 @@ public class FarmService {
     public void decreaseLike(Long farmId) {
         Farm farm = farmRepository.findByIdOrThrow(farmId);
         farm.updateFavoriteCount(farm.getFavoriteCount() - 1);
+    }
+
+
+    // 반정규화를 위해 넣어놓은 Farm > orderCount를 증가/감소시키는 이벤트 처리
+    @Transactional
+    @KafkaListener(topics = "order-count-topic", groupId = "order-group", containerFactory = "kafkaListenerContainerFactory")
+    public void consumeIssueNotification(String message /*listen 하면 스트링 형태로 메시지가 들어온다*/) {
+        log.info("line 248 >>>>> [Product Module] update order Count");
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            KafkaOrderCountUpdateRequest request = objectMapper.readValue(message, KafkaOrderCountUpdateRequest.class);
+            Farm farm = farmRepository.findByIdOrThrow(request.farmId());
+
+            log.info("line 254 >>>> {}", request);
+
+            switch(request.orderCountRequestType()) {
+                case INCREASE -> farm.updateOrderCount(farm.getOrderCount() + 1);
+                case DECREASE -> farm.updateOrderCount(farm.getOrderCount() - 1);
+                default -> throw new BaseCustomException(FarmExceptionType.INVALID_ORDER_COUNT_REQUEST);
+            }
+        } catch (JsonProcessingException e) {
+            throw new BaseCustomException(INVALID_FCM_REQUEST);
+        } catch(Exception e) {
+            throw new BaseCustomException(FCM_SEND_FAIL);
+        }
     }
 
 }


### PR DESCRIPTION
## 📌 PR 타입
<!-- [x] 이렇게하면 체크돼요 -->
- [ ] 기능 추가
- [ ] 기능 수정
- [ ] 리팩토링
- [ ] docs 작업


## 📄 작업 내용
<!-- ex) 구글 소셜 로그인 기능추가, 프로젝트 모집글 쓰기 API 작성 -->


## 📷 결과 화면
<!-- 포스트맨 실행결과를 캡처해주세요 -->
이 상태에서 주문(결제)를 하면
<img width="588" alt="스크린샷 2024-10-15 오후 9 04 56" src="https://github.com/user-attachments/assets/c743ee04-efe2-4f5a-81f2-42d27517b469">

`order_count`가 증가합니다
<img width="597" alt="스크린샷 2024-10-15 오후 9 05 06" src="https://github.com/user-attachments/assets/0929e977-74a2-4170-9af1-02a9a1026c93">
<img width="1213" alt="스크린샷 2024-10-15 오후 9 07 57" src="https://github.com/user-attachments/assets/920576ae-c553-475e-8775-795c867de52c">


## ✔️ 기타 사항
<!-- 리뷰 받고 싶은 포인트를 적어주세요! -->

## 🌳 작업 브랜치
<!--ex)  feat/IS-1  -->
closed #265 