### PR TITLE
fix: 판매자 판매건수, 매출 내역 페이지 관련 API 수정

### DIFF
--- a/backend/order/src/main/java/org/samtuap/inong/common/client/ProductFeign.java
+++ b/backend/order/src/main/java/org/samtuap/inong/common/client/ProductFeign.java
@@ -4,6 +4,7 @@ import org.samtuap.inong.config.FeignConfig;
 import org.samtuap.inong.domain.delivery.dto.FarmDetailGetResponse;
 import org.samtuap.inong.domain.coupon.dto.FarmSellerResponse;
 import org.samtuap.inong.domain.delivery.dto.PackageProductResponse;
+import org.samtuap.inong.domain.order.dto.PackageStatisticResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -30,5 +31,8 @@ public interface ProductFeign {
     // TODO: 아직 구현 안됨. 추후 구현 예정. 삭제가 된 상품까지 다 들고 오기
     @PostMapping(value = "/product/info/contain-deleted")
     List<PackageProductResponse> getPackageProductListContainDeleted(@RequestBody List<Long> ids);
+
+    @PostMapping("/product/info/contain-deleted/name-only")
+    List<PackageStatisticResponse> getPackageProductListContainDeletedNameOnly(@RequestBody List<Long> ids);
 
 }

--- a/backend/order/src/main/java/org/samtuap/inong/domain/order/api/OrderBackOfficeController.java
+++ b/backend/order/src/main/java/org/samtuap/inong/domain/order/api/OrderBackOfficeController.java
@@ -3,6 +3,7 @@ package org.samtuap.inong.domain.order.api;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.samtuap.inong.domain.order.dto.SalesDataGetResponse;
+import org.samtuap.inong.domain.order.dto.SalesDataWithPackagesGetResponse;
 import org.samtuap.inong.domain.order.dto.SalesElementGetResponse;
 import org.samtuap.inong.domain.order.dto.SalesTableGetRequest;
 import org.samtuap.inong.domain.order.service.OrderBackOfficeService;
@@ -13,6 +14,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 // 사장님 페이지 > 매출
@@ -31,9 +33,20 @@ public class OrderBackOfficeController {
 
 
     @PostMapping("/sales-list")
-    public ResponseEntity<List<SalesElementGetResponse>> getSalesList(@RequestBody SalesTableGetRequest request,
-                                                                      @RequestHeader("sellerId") Long sellerId) {
-        List<SalesElementGetResponse> salesList = orderBackOfficeService.getSalesList(request, sellerId);
+    public ResponseEntity<Page<SalesElementGetResponse>> getSalesList(@RequestBody SalesTableGetRequest request,
+                                                                      @RequestHeader("sellerId") Long sellerId,
+                                                                      @PageableDefault(size = 10, page = 0) Pageable pageable) {
+        Page<SalesElementGetResponse> salesList = orderBackOfficeService.getSalesList(pageable, request, sellerId);
         return new ResponseEntity<>(salesList, HttpStatus.OK);
+    }
+
+    @GetMapping("/package-sales-data")
+    public ResponseEntity<SalesDataWithPackagesGetResponse> getSalesDataWithPackages(@RequestParam LocalDateTime startTime,
+                                                                                     @RequestParam LocalDateTime endTime,
+                                                                                     @RequestParam boolean onlyFirstSubscription,
+                                                                                     @RequestHeader("sellerId") Long sellerId) {
+        SalesTableGetRequest request = new SalesTableGetRequest(startTime, endTime, onlyFirstSubscription);
+        SalesDataWithPackagesGetResponse salesData = orderBackOfficeService.getSalesDataWithPackages(request, sellerId);
+        return new ResponseEntity<>(salesData, HttpStatus.OK);
     }
 }

--- a/backend/order/src/main/java/org/samtuap/inong/domain/order/dto/PackageOrderCount.java
+++ b/backend/order/src/main/java/org/samtuap/inong/domain/order/dto/PackageOrderCount.java
@@ -1,0 +1,13 @@
+package org.samtuap.inong.domain.order.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PackageOrderCount {
+    private Long packageId;
+    private Long count;
+}

--- a/backend/order/src/main/java/org/samtuap/inong/domain/order/dto/PackageStatisticResponse.java
+++ b/backend/order/src/main/java/org/samtuap/inong/domain/order/dto/PackageStatisticResponse.java
@@ -1,0 +1,14 @@
+package org.samtuap.inong.domain.order.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class PackageStatisticResponse {
+    private Long id;
+    private String packageName;
+    private Long amount;
+}

--- a/backend/order/src/main/java/org/samtuap/inong/domain/order/dto/SalesDataByYearAndMonth.java
+++ b/backend/order/src/main/java/org/samtuap/inong/domain/order/dto/SalesDataByYearAndMonth.java
@@ -1,0 +1,13 @@
+package org.samtuap.inong.domain.order.dto;
+
+import lombok.*;
+
+@ToString
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class SalesDataByYearAndMonth {
+    private Long count;
+    private Long amount;
+}

--- a/backend/order/src/main/java/org/samtuap/inong/domain/order/dto/SalesDataGetResponse.java
+++ b/backend/order/src/main/java/org/samtuap/inong/domain/order/dto/SalesDataGetResponse.java
@@ -1,6 +1,15 @@
 package org.samtuap.inong.domain.order.dto;
 
-import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 
-public record SalesDataGetResponse(Long totalCount, Long totalSalesAmount) {
+import java.util.List;
+
+@Builder
+public record SalesDataGetResponse(Long totalCount,
+                                   Long totalSalesAmount,
+                                   List<String> labels,
+                                   List<Long> monthSaleCount,
+                                   List<Long> monthSaleAmount) {
 }

--- a/backend/order/src/main/java/org/samtuap/inong/domain/order/dto/SalesDataWithPackagesGetResponse.java
+++ b/backend/order/src/main/java/org/samtuap/inong/domain/order/dto/SalesDataWithPackagesGetResponse.java
@@ -1,0 +1,7 @@
+package org.samtuap.inong.domain.order.dto;
+
+import java.util.List;
+
+public record SalesDataWithPackagesGetResponse(List<String> labels, List<Long> count) {
+
+}

--- a/backend/order/src/main/java/org/samtuap/inong/domain/order/repository/OrderRepository.java
+++ b/backend/order/src/main/java/org/samtuap/inong/domain/order/repository/OrderRepository.java
@@ -33,4 +33,7 @@ public interface OrderRepository extends JpaRepository<Ordering, Long> {
 
     List<Ordering> findAllByMemberId(Long memberId);
 
+    @Query("SELECT o.packageId FROM Ordering o WHERE o.farmId = :farmId AND o.createdAt >= :startAt AND o.createdAt <= :endAt")
+    List<Long> findAllByFarmIdAndBetweenStartAtAndEndAt(Long farmId, LocalDateTime startAt, LocalDateTime endAt);
+
 }

--- a/backend/order/src/main/java/org/samtuap/inong/domain/order/repository/OrderRepository.java
+++ b/backend/order/src/main/java/org/samtuap/inong/domain/order/repository/OrderRepository.java
@@ -1,6 +1,8 @@
 package org.samtuap.inong.domain.order.repository;
 
 
+import org.samtuap.inong.domain.order.dto.PackageOrderCount;
+import org.samtuap.inong.domain.order.dto.PackageProductOrderResponse;
 import org.samtuap.inong.domain.order.dto.SalesDataGetResponse;
 import org.samtuap.inong.domain.order.dto.TopPackageResponse;
 import org.samtuap.inong.domain.order.entity.Ordering;
@@ -33,7 +35,7 @@ public interface OrderRepository extends JpaRepository<Ordering, Long> {
 
     List<Ordering> findAllByMemberId(Long memberId);
 
-    @Query("SELECT o.packageId FROM Ordering o WHERE o.farmId = :farmId AND o.createdAt >= :startAt AND o.createdAt <= :endAt")
-    List<Long> findAllByFarmIdAndBetweenStartAtAndEndAt(Long farmId, LocalDateTime startAt, LocalDateTime endAt);
+    @Query("SELECT new org.samtuap.inong.domain.order.dto.PackageOrderCount(o.packageId, COUNT(o.id)) FROM Ordering o WHERE o.farmId = :farmId AND o.createdAt >= :startAt AND o.createdAt <= :endAt GROUP BY o.packageId")
+    List<PackageOrderCount> findAllByFarmIdAndBetweenStartAtAndEndAt(Long farmId, LocalDateTime startAt, LocalDateTime endAt);
 
 }

--- a/backend/order/src/main/java/org/samtuap/inong/domain/order/service/OrderBackOfficeService.java
+++ b/backend/order/src/main/java/org/samtuap/inong/domain/order/service/OrderBackOfficeService.java
@@ -45,9 +45,9 @@ public class OrderBackOfficeService {
         return salesData;
     }
 
-    public List<SalesElementGetResponse> getSalesList(SalesTableGetRequest request, Long sellerId) {
+    public Page<SalesElementGetResponse> getSalesList(SalesTableGetRequest request, Long sellerId) {
         FarmDetailGetResponse farmInfo = productFeign.getFarmInfoWithSeller(sellerId);
-        List<Receipt> receipts = null;
+        Page<Receipt> receipts = null;
         if(!request.onlyFirstSubscription()) {
             receipts = receiptRepository.findAllByOrderFarmId(farmInfo.id(), request.startTime(), request.endTime());
         } else {
@@ -61,7 +61,7 @@ public class OrderBackOfficeService {
         List<MemberDetailResponse> memberList = memberFeign.getMemberByIdsContainDeleted(memberIds);
 
 
-        return receipts.stream().map(r -> {
+        return receipts.map(r -> {
             PackageProductResponse packageProduct = packageProductList.stream()
                     .filter(p -> p.id().equals(r.getOrder().getPackageId()))
                     .findFirst()
@@ -73,6 +73,6 @@ public class OrderBackOfficeService {
                     .orElseThrow(() -> new BaseCustomException(INVALID_MEMBER_ID));
 
             return SalesElementGetResponse.fromEntity(r, packageProduct, memberDetail);
-        }).toList();
+        });
     }
 }

--- a/backend/order/src/main/java/org/samtuap/inong/domain/order/service/OrderBackOfficeService.java
+++ b/backend/order/src/main/java/org/samtuap/inong/domain/order/service/OrderBackOfficeService.java
@@ -5,21 +5,21 @@ import lombok.extern.slf4j.Slf4j;
 import org.samtuap.inong.common.client.MemberFeign;
 import org.samtuap.inong.common.client.ProductFeign;
 import org.samtuap.inong.common.exception.BaseCustomException;
-import org.samtuap.inong.common.exceptionType.OrderExceptionType;
 import org.samtuap.inong.domain.delivery.dto.FarmDetailGetResponse;
 import org.samtuap.inong.domain.delivery.dto.MemberDetailResponse;
 import org.samtuap.inong.domain.delivery.dto.PackageProductResponse;
-import org.samtuap.inong.domain.order.dto.SalesDataGetResponse;
-import org.samtuap.inong.domain.order.dto.SalesElementGetResponse;
-import org.samtuap.inong.domain.order.dto.SalesTableGetRequest;
+import org.samtuap.inong.domain.order.dto.*;
 import org.samtuap.inong.domain.order.repository.OrderRepository;
 import org.samtuap.inong.domain.receipt.entity.Receipt;
 import org.samtuap.inong.domain.receipt.repository.ReceiptRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.samtuap.inong.common.exceptionType.OrderExceptionType.*;
 
@@ -28,30 +28,27 @@ import static org.samtuap.inong.common.exceptionType.OrderExceptionType.*;
 @Service
 public class OrderBackOfficeService {
     private final ReceiptRepository receiptRepository;
-    private final OrderRepository orderRepository;
     private final ProductFeign productFeign;
     private final MemberFeign memberFeign;
+    private final OrderRepository orderRepository;
 
     public SalesDataGetResponse getSalesData(SalesTableGetRequest request, Long sellerId) {
-
         FarmDetailGetResponse farmInfo = productFeign.getFarmInfoWithSeller(sellerId);
-        SalesDataGetResponse salesData = null;
-        if(!request.onlyFirstSubscription()) {
-            salesData = receiptRepository.findSalesData(farmInfo.id(), request.startTime(), request.endTime());
-        } else {
-            salesData = receiptRepository.findSalesDataFirstOnly(farmInfo.id(), request.startTime(), request.endTime());
-        }
 
-        return salesData;
+        if(request.onlyFirstSubscription()) {
+            return getVisualizationSalesDataOnlyFirst(farmInfo.id(), request);
+        } else {
+            return getVisualizationSalesData(farmInfo.id(), request);
+        }
     }
 
-    public Page<SalesElementGetResponse> getSalesList(SalesTableGetRequest request, Long sellerId) {
+    public Page<SalesElementGetResponse> getSalesList(Pageable pageable, SalesTableGetRequest request, Long sellerId) {
         FarmDetailGetResponse farmInfo = productFeign.getFarmInfoWithSeller(sellerId);
         Page<Receipt> receipts = null;
         if(!request.onlyFirstSubscription()) {
-            receipts = receiptRepository.findAllByOrderFarmId(farmInfo.id(), request.startTime(), request.endTime());
+            receipts = receiptRepository.findAllByOrderFarmId(pageable, farmInfo.id(), request.startTime(), request.endTime());
         } else {
-            receipts = receiptRepository.findAllByOrderFarmIdFirstOnly(farmInfo.id(), request.startTime(), request.endTime());
+            receipts = receiptRepository.findAllByOrderFarmIdFirstOnly(pageable, farmInfo.id(), request.startTime(), request.endTime());
         }
 
         List<Long> packageIds = receipts.stream().map(r -> r.getOrder().getPackageId()).toList();
@@ -74,5 +71,110 @@ public class OrderBackOfficeService {
 
             return SalesElementGetResponse.fromEntity(r, packageProduct, memberDetail);
         });
+    }
+
+
+    // 시각화를 위한 데이터 만들기
+    private SalesDataGetResponse getVisualizationSalesData(Long farmId, SalesTableGetRequest request) {
+        LocalDateTime curTime = request.startTime();
+        LocalDateTime endTime = request.endTime();
+        boolean isFirstOrder = request.onlyFirstSubscription();
+
+        List<String> labels = new ArrayList<>();
+        List<Long> monthSaleCount = new ArrayList<>();
+        List<Long> monthSaleAmount = new ArrayList<>();
+        Long totalCount = 0L, totalSalesAmount = 0L;
+        while(!(curTime.getYear() == endTime.getYear() && curTime.getMonthValue() == endTime.getMonthValue())) {
+            int year = curTime.getYear();
+            int month = curTime.getMonthValue();
+            SalesDataByYearAndMonth monthSaleData = receiptRepository.findSalesDataByYearAndMonth(farmId, year, month);
+
+            if(monthSaleData.getAmount() == null) {
+                monthSaleData.setAmount(0L);
+            }
+
+            labels.add(year+"."+month);
+            monthSaleCount.add(monthSaleData.getCount());
+            monthSaleAmount.add(monthSaleData.getAmount());
+
+            totalCount += monthSaleData.getCount();
+            totalSalesAmount += monthSaleData.getAmount();
+
+
+            curTime = curTime.plusMonths(1);
+        }
+
+        return SalesDataGetResponse.builder()
+                .labels(labels)
+                .monthSaleAmount(monthSaleAmount)
+                .monthSaleCount(monthSaleCount)
+                .totalCount(totalCount)
+                .totalSalesAmount(totalSalesAmount)
+                .build();
+    }
+
+    // 시각화를 위한 데이터 만들기
+    private SalesDataGetResponse getVisualizationSalesDataOnlyFirst(Long farmId, SalesTableGetRequest request) {
+        LocalDateTime curTime = request.startTime();
+        LocalDateTime endTime = request.endTime();
+        boolean isFirstOrder = request.onlyFirstSubscription();
+
+        List<String> labels = new ArrayList<>();
+        List<Long> monthSaleCount = new ArrayList<>();
+        List<Long> monthSaleAmount = new ArrayList<>();
+        Long totalCount = 0L, totalSalesAmount = 0L;
+        while(true) {
+            int year = curTime.getYear();
+            int month = curTime.getMonthValue();
+            SalesDataByYearAndMonth monthSaleData = receiptRepository.findSalesDataByYearAndMonthFirstOnly(farmId, year, month, isFirstOrder);
+
+
+            if(monthSaleData.getAmount() == null) {
+                monthSaleData.setAmount(0L);
+            }
+
+            labels.add(year+"."+month);
+            monthSaleCount.add(monthSaleData.getCount());
+            monthSaleAmount.add(monthSaleData.getAmount());
+
+            totalCount += monthSaleData.getCount();
+            totalSalesAmount += monthSaleData.getAmount();
+
+            if(year == endTime.getYear() && month == endTime.getMonthValue()) {
+                break;
+            }
+
+            curTime = curTime.plusMonths(1);
+        }
+
+        return SalesDataGetResponse.builder()
+                .labels(labels)
+                .monthSaleAmount(monthSaleAmount)
+                .monthSaleCount(monthSaleCount)
+                .totalCount(totalCount)
+                .totalSalesAmount(totalSalesAmount)
+                .build();
+    }
+
+    public SalesDataWithPackagesGetResponse getSalesDataWithPackages(SalesTableGetRequest request, Long sellerId) {
+        FarmDetailGetResponse farmInfo = productFeign.getFarmInfoWithSeller(sellerId);
+        List<Long> packageIds = orderRepository.findAllByFarmIdAndBetweenStartAtAndEndAt(farmInfo.id(), request.startTime(), request.endTime());
+        Map<Long, Long> countWithPackage = new HashMap<>();
+
+        for (Long packageId : packageIds) {
+            Long packageCount = countWithPackage.getOrDefault(packageId, 0L);
+            countWithPackage.put(packageId, packageCount + 1);
+        }
+
+        List<PackageStatisticResponse> packageNames = productFeign.getPackageProductListContainDeletedNameOnly(packageIds);
+        List<String> labels = new ArrayList<>();
+        List<Long> count = new ArrayList<>();
+//        List<Long> amount = new ArrayList<>();
+        for(PackageStatisticResponse dto : packageNames) {
+            labels.add(dto.getPackageName());
+            count.add(countWithPackage.get(dto.getId()));
+        }
+        
+        return new SalesDataWithPackagesGetResponse(labels, count);
     }
 }

--- a/backend/order/src/main/java/org/samtuap/inong/domain/receipt/repository/ReceiptRepository.java
+++ b/backend/order/src/main/java/org/samtuap/inong/domain/receipt/repository/ReceiptRepository.java
@@ -3,6 +3,7 @@ package org.samtuap.inong.domain.receipt.repository;
 import org.samtuap.inong.common.exception.BaseCustomException;
 import org.samtuap.inong.common.exceptionType.OrderExceptionType;
 import org.samtuap.inong.common.exceptionType.ReceiptExceptionType;
+import org.samtuap.inong.domain.order.dto.SalesDataByYearAndMonth;
 import org.samtuap.inong.domain.order.dto.SalesDataGetResponse;
 import org.samtuap.inong.domain.order.entity.Ordering;
 import org.samtuap.inong.domain.receipt.entity.Receipt;
@@ -26,29 +27,31 @@ public interface ReceiptRepository extends JpaRepository<Receipt, Long> {
         return findByOrder(order).orElseThrow(() -> new BaseCustomException(ORDER_NOT_FOUND));
     }
 
-    @Query("SELECT new org.samtuap.inong.domain.order.dto.SalesDataGetResponse(COUNT(*), SUM(r.totalPrice)) " +
+    @Query("SELECT new org.samtuap.inong.domain.order.dto.SalesDataByYearAndMonth(COUNT(*), SUM(r.totalPrice)) " +
             "FROM Receipt r " +
-            "WHERE r.order.farmId = :farmId AND r.createdAt >= :startTime AND r.createdAt <= :endTime AND r.order.canceledAt IS NULL")
-    SalesDataGetResponse findSalesData(@Param("farmId") Long farmId, @Param("startTime") LocalDateTime startTime, @Param("endTime") LocalDateTime endTime);
+            "WHERE r.order.farmId = :farmId AND YEAR(r.createdAt) = :year AND MONTH(r.createdAt) = :month AND r.order.isFirst = :isFirst AND r.order.canceledAt IS NULL")
+    SalesDataByYearAndMonth findSalesDataByYearAndMonthFirstOnly(@Param("farmId") Long farmId, @Param("year") int year, @Param("month") int month, boolean isFirst);
 
-    @Query("SELECT new org.samtuap.inong.domain.order.dto.SalesDataGetResponse(COUNT(*), SUM(r.totalPrice)) " +
+    @Query("SELECT new org.samtuap.inong.domain.order.dto.SalesDataByYearAndMonth(COUNT(*), SUM(r.totalPrice)) " +
             "FROM Receipt r " +
-            "WHERE r.order.farmId = :farmId AND r.createdAt >= :startTime AND r.createdAt <= :endTime AND r.order.isFirst = true AND r.order.canceledAt IS NULL")
-    SalesDataGetResponse findSalesDataFirstOnly(@Param("farmId") Long farmId, @Param("startTime") LocalDateTime startTime, @Param("endTime") LocalDateTime endTime);
+            "WHERE r.order.farmId = :farmId AND YEAR(r.createdAt) = :year AND MONTH(r.createdAt) = :month AND r.order.canceledAt IS NULL")
+    SalesDataByYearAndMonth findSalesDataByYearAndMonth(@Param("farmId") Long farmId, @Param("year") int year, @Param("month") int month);
 
     @Query("SELECT r " +
             "FROM Receipt r " +
             "WHERE r.order.farmId = :farmId AND r.createdAt >= :startTime AND r.createdAt <= :endTime AND r.order.isFirst = true AND r.order.canceledAt IS NULL " +
             "ORDER BY r.createdAt DESC")
-    Page<Receipt> findAllByOrderFarmIdFirstOnly(@Param("farmId") Long farmId, @Param("startTime") LocalDateTime startTime, @Param("endTime") LocalDateTime endTime);
+    Page<Receipt> findAllByOrderFarmIdFirstOnly(Pageable pageable, @Param("farmId") Long farmId, @Param("startTime") LocalDateTime startTime, @Param("endTime") LocalDateTime endTime);
 
     @Query("SELECT r " +
             "FROM Receipt r " +
             "WHERE r.order.farmId = :farmId AND r.createdAt >= :startTime AND r.createdAt <= :endTime AND r.order.canceledAt IS NULL " +
             "ORDER BY r.createdAt DESC")
-    Page<Receipt> findAllByOrderFarmId(@Param("farmId") Long farmId, @Param("startTime") LocalDateTime startTime, @Param("endTime") LocalDateTime endTime);
+    Page<Receipt> findAllByOrderFarmId(Pageable pageable, @Param("farmId") Long farmId, @Param("startTime") LocalDateTime startTime, @Param("endTime") LocalDateTime endTime);
 
     default Receipt findByIdOrThrow(Long id) {
         return findById(id).orElseThrow(() -> new BaseCustomException(RECEIPT_NOT_FOUND));
     }
+
+
 }

--- a/backend/order/src/main/java/org/samtuap/inong/domain/receipt/repository/ReceiptRepository.java
+++ b/backend/order/src/main/java/org/samtuap/inong/domain/receipt/repository/ReceiptRepository.java
@@ -40,13 +40,13 @@ public interface ReceiptRepository extends JpaRepository<Receipt, Long> {
             "FROM Receipt r " +
             "WHERE r.order.farmId = :farmId AND r.createdAt >= :startTime AND r.createdAt <= :endTime AND r.order.isFirst = true AND r.order.canceledAt IS NULL " +
             "ORDER BY r.createdAt DESC")
-    List<Receipt> findAllByOrderFarmIdFirstOnly(@Param("farmId") Long farmId, @Param("startTime") LocalDateTime startTime, @Param("endTime") LocalDateTime endTime);
+    Page<Receipt> findAllByOrderFarmIdFirstOnly(@Param("farmId") Long farmId, @Param("startTime") LocalDateTime startTime, @Param("endTime") LocalDateTime endTime);
 
     @Query("SELECT r " +
             "FROM Receipt r " +
             "WHERE r.order.farmId = :farmId AND r.createdAt >= :startTime AND r.createdAt <= :endTime AND r.order.canceledAt IS NULL " +
             "ORDER BY r.createdAt DESC")
-    List<Receipt> findAllByOrderFarmId(@Param("farmId") Long farmId, @Param("startTime") LocalDateTime startTime, @Param("endTime") LocalDateTime endTime);
+    Page<Receipt> findAllByOrderFarmId(@Param("farmId") Long farmId, @Param("startTime") LocalDateTime startTime, @Param("endTime") LocalDateTime endTime);
 
     default Receipt findByIdOrThrow(Long id) {
         return findById(id).orElseThrow(() -> new BaseCustomException(RECEIPT_NOT_FOUND));

--- a/backend/product/src/main/java/org/samtuap/inong/domain/farm/service/FarmService.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/farm/service/FarmService.java
@@ -100,7 +100,6 @@ public class FarmService {
         });
     }
 
-
     public List<FarmFavoriteResponse> getFarmFavoriteList(List<Long> farmFavoriteIds) {
         List<Farm> farmFavoriteList = farmRepository.findByIdIn(farmFavoriteIds);
         List<FarmFavoriteResponse> tmp = farmFavoriteList.stream()
@@ -108,7 +107,6 @@ public class FarmService {
                 .collect(Collectors.toList());
         return tmp;
     }
-
 
     /**
      * feign 요청용

--- a/backend/product/src/main/java/org/samtuap/inong/domain/product/api/PackageProductController.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/product/api/PackageProductController.java
@@ -75,6 +75,13 @@ public class PackageProductController {
         return packageProductService.getProductInfoListContainDeleted(ids);
     }
 
+
+    // Feign 요청용 메서드
+    @PostMapping("/info/contain-deleted/name-only")
+    List<PackageStatisticResponse> getPackageProductListContainDeletedNameOnly(@RequestBody List<Long> ids) {
+        return packageProductService.getProductInfoListContainDeletedNameOnly(ids);
+    }
+
     @GetMapping("/no-auth/for-sale/{id}")
     public List<PackageProductForSaleListResponse> getForSalePackageProduct(@PathVariable("id") Long farmId) {
         return packageProductService.getForSalePackageProduct(farmId);

--- a/backend/product/src/main/java/org/samtuap/inong/domain/product/dto/PackageProductResponse.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/product/dto/PackageProductResponse.java
@@ -36,4 +36,5 @@ public record PackageProductResponse(Long id,
                 .origin(packageProduct.getOrigin())
                 .build();
     }
+
 }

--- a/backend/product/src/main/java/org/samtuap/inong/domain/product/dto/PackageStatisticResponse.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/product/dto/PackageStatisticResponse.java
@@ -1,0 +1,14 @@
+package org.samtuap.inong.domain.product.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class PackageStatisticResponse {
+    private Long id;
+    private String packageName;
+    private Long amount;
+}

--- a/backend/product/src/main/java/org/samtuap/inong/domain/product/dto/PackageStatisticResponse.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/product/dto/PackageStatisticResponse.java
@@ -10,5 +10,4 @@ import lombok.NoArgsConstructor;
 public class PackageStatisticResponse {
     private Long id;
     private String packageName;
-    private Long amount;
 }

--- a/backend/product/src/main/java/org/samtuap/inong/domain/product/entity/PackageProduct.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/product/entity/PackageProduct.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 import org.samtuap.inong.domain.common.BaseEntity;
@@ -36,6 +37,7 @@ public class PackageProduct extends BaseEntity {
     @NotNull
     private Long price;
 
+    @Column(columnDefinition = "text")
     private String productDescription;
 
     private String productCode;

--- a/backend/product/src/main/java/org/samtuap/inong/domain/product/repository/PackageProductRepository.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/product/repository/PackageProductRepository.java
@@ -38,6 +38,6 @@ public interface PackageProductRepository extends JpaRepository<PackageProduct, 
 
     Page<PackageProduct> findAll(Specification<PackageProduct> specification, Pageable pageable);
 
-    @Query(value = "SELECT DISTINCT new org.samtuap.inong.domain.product.dto.PackageStatisticResponse(p.id, p.packageName) FROM PackageProduct p WHERE p.id IN :ids", nativeQuery = true)
+    @Query("SELECT new org.samtuap.inong.domain.product.dto.PackageStatisticResponse(p.id, p.packageName) FROM PackageProduct p WHERE p.id IN :ids")
     List<PackageStatisticResponse> findAllByIdContainDeletedNameOnly(List<Long> ids);
 }

--- a/backend/product/src/main/java/org/samtuap/inong/domain/product/repository/PackageProductRepository.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/product/repository/PackageProductRepository.java
@@ -1,7 +1,7 @@
 package org.samtuap.inong.domain.product.repository;
 
 import org.samtuap.inong.common.exception.BaseCustomException;
-import org.samtuap.inong.domain.farm.entity.Farm;
+import org.samtuap.inong.domain.product.dto.PackageStatisticResponse;
 import org.samtuap.inong.domain.product.entity.PackageProduct;
 import org.samtuap.inong.domain.product.entity.PackageProductImage;
 import org.springframework.data.domain.Page;
@@ -33,8 +33,11 @@ public interface PackageProductRepository extends JpaRepository<PackageProduct, 
 
     List<PackageProduct> findAllByFarmId(Long farmId);
 
-    @Query("SELECT f FROM Farm f ORDER BY f.id DESC LIMIT :n")
+    @Query(value = "SELECT f FROM Farm f ORDER BY f.id DESC LIMIT :n", nativeQuery = true)
     List<PackageProductImage> findNPackageProducts(@Param("n") Long n);
 
     Page<PackageProduct> findAll(Specification<PackageProduct> specification, Pageable pageable);
+
+    @Query(value = "SELECT DISTINCT new org.samtuap.inong.domain.product.dto.PackageStatisticResponse(p.id, p.packageName) FROM PackageProduct p WHERE p.id IN :ids", nativeQuery = true)
+    List<PackageStatisticResponse> findAllByIdContainDeletedNameOnly(List<Long> ids);
 }

--- a/backend/product/src/main/java/org/samtuap/inong/domain/product/service/PackageProductService.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/product/service/PackageProductService.java
@@ -151,6 +151,10 @@ public class PackageProductService {
         return packageProducts.stream()
                 .map(p -> PackageProductResponse.fromEntity(p, new ArrayList<>())).toList();
     }
+
+    public List<PackageStatisticResponse> getProductInfoListContainDeletedNameOnly(List<Long> ids) {
+        return packageProductRepository.findAllByIdContainDeletedNameOnly(ids);
+    }
   
     @Transactional
     public List<PackageProductSubsResponse> getProductSubsList(List<Long> subscriptionIds) {


### PR DESCRIPTION
## 📌 PR 타입
<!-- [x] 이렇게하면 체크돼요 -->
- [x] 기능 추가
- [x] 기능 수정
- [ ] 리팩토링
- [ ] docs 작업


## 📄 작업 내용
<!-- ex) 구글 소셜 로그인 기능추가, 프로젝트 모집글 쓰기 API 작성 -->
- 판매자 페이지의 매출 내역, 판매 건수 관련 API를 수정했습니다.
- 패키지별 판매 건수 API 구현을 시도했는데, 완성하지 못했습니다ㅠ 작업이 너무 길어지는 것 같아 일단 PR 보내고 FarmList 페이지로 넘어가 보겠습니다.

- farmList 응답 값에 farmIntro를 추가했습니다.
- package 설명 컬럼을 길이 제한 때문에 TEXT 타입으로 변경했습니다.

## 📷 결과 화면
<!-- 포스트맨 실행결과를 캡처해주세요 -->

## ✔️ 기타 사항
<!-- 리뷰 받고 싶은 포인트를 적어주세요! -->

## 🌳 작업 브랜치
<!--ex)  feat/IS-1  -->

closed #268 