### PR TITLE
chore: 라이브 화면에서 시청인원 표시

### DIFF
--- a/backend/live/src/main/java/org/samtuap/inong/domain/live/api/LiveController.java
+++ b/backend/live/src/main/java/org/samtuap/inong/domain/live/api/LiveController.java
@@ -40,4 +40,10 @@ public class LiveController {
     public List<FavoritesLiveListResponse> getFavoritesFarmLiveList(@RequestBody List<Long> favoriteFarmList) {
         return liveService.getFavoritesFarmLiveList(favoriteFarmList);
     }
+
+    @GetMapping("/{sessionId}/participants")
+    public ResponseEntity<Integer> getParticipantCount(@PathVariable String sessionId) {
+        int count = liveService.getParticipantCount(sessionId);
+        return ResponseEntity.ok(count);
+    }
 }

--- a/backend/live/src/main/java/org/samtuap/inong/domain/live/service/LiveService.java
+++ b/backend/live/src/main/java/org/samtuap/inong/domain/live/service/LiveService.java
@@ -35,6 +35,7 @@ public class LiveService {
     private final OpenVidu openVidu;
     private final SocketController socketController;
     private final RedisTemplate<String, Object> redisTemplate;
+    private static final String LIVE_PARTICIPANTS_KEY_PREFIX = "live:participants:";
 
     /**
      * feign 요청용
@@ -113,5 +114,11 @@ public class LiveService {
         redisTemplate.expire("live:participants:" + sessionId, 1, TimeUnit.HOURS);
         redisTemplate.expire("kicked:users:" + sessionId, 1, TimeUnit.HOURS);
         liveRepository.save(live);
+    }
+
+    public int getParticipantCount(String sessionId) {
+        String key = LIVE_PARTICIPANTS_KEY_PREFIX + sessionId;
+        Integer count = (Integer) redisTemplate.opsForValue().get(key);
+        return (count != null) ? count : 0;
     }
 }


### PR DESCRIPTION
## 📌 PR 타입
<!-- [x] 이렇게하면 체크돼요 -->
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 리팩토링
- [ ] docs 작업


## 📄 작업 내용
<!-- ex) 구글 소셜 로그인 기능추가, 프로젝트 모집글 쓰기 API 작성 -->
- 라이브 화면에서 시청 인원을 표시하기 위한 api 추가했습니다.


## 📷 결과 화면
<!-- 포스트맨 실행결과를 캡처해주세요 -->
- clientpr에 결과 첨부했습니다.

## ✔️ 기타 사항
<!-- 리뷰 받고 싶은 포인트를 적어주세요! -->

## 🌳 작업 브랜치
<!--ex)  feat/IS-1  -->
closed #282 