### PR TITLE
fix: 배송 주기 에러 수정

### DIFF
--- a/backend/order/src/main/java/org/samtuap/inong/domain/order/service/OrderService.java
+++ b/backend/order/src/main/java/org/samtuap/inong/domain/order/service/OrderService.java
@@ -205,7 +205,7 @@ public class OrderService {
             Delivery delivery = Delivery.builder()
                     .ordering(ordering)
                     .deliveryStatus(BEFORE_DELIVERY)
-                    .deliveryDueDate(LocalDate.now().plusDays(time))
+                    .deliveryDueDate(LocalDate.now().plusDays((long) time * packageProduct.delivery_cycle()))
                     .courier("CJ") // FIXME: 논의 필요
                     .build();
             deliveryRepository.save(delivery);


### PR DESCRIPTION
## 📌 PR 타입
<!-- [x] 이렇게하면 체크돼요 -->
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 리팩토링
- [ ] docs 작업


## 📄 작업 내용
<!-- ex) 구글 소셜 로그인 기능추가, 프로젝트 모집글 쓰기 API 작성 -->
배송주기가 잘못 들어가고 있는 에러를 수정했습니다!

## 📷 결과 화면
<!-- 포스트맨 실행결과를 캡처해주세요 -->
배송주기가 1일인 상품을 주문했을 때 => 28개의 배송데이터가 1일 간격으로 추가
<img width="1343" alt="스크린샷 2024-10-19 오후 9 41 31" src="https://github.com/user-attachments/assets/d9ea54da-defb-46ca-994c-e29b485388e3">

배송주기가 7일인 상품을 주문했을 때 => 4개의 배송 데이터가 7일 간격으로 추가
<img width="1339" alt="스크린샷 2024-10-19 오후 9 44 42" src="https://github.com/user-attachments/assets/1429260d-ef05-473f-834c-09498311dbbc">


## ✔️ 기타 사항
<!-- 리뷰 받고 싶은 포인트를 적어주세요! -->

## 🌳 작업 브랜치
<!--ex)  feat/IS-1  -->
closed #289 