### PR TITLE
feat: 메인 페이지 > 라이브 목록 시청순 best5 출력

### DIFF
--- a/backend/apigateway/src/main/java/org/samtuap/inong/securities/JwtGlobalFilter.java
+++ b/backend/apigateway/src/main/java/org/samtuap/inong/securities/JwtGlobalFilter.java
@@ -36,7 +36,7 @@ public class JwtGlobalFilter implements GlobalFilter {
 
     private final List<String> allowUrl = Arrays.asList("/member/sign-in", "/member/sign-up", "/seller/sign-in", "/seller/request-auth-code", "/seller/verify-email", "/seller/sign-up", "/seller/check-email", "/member/create-token",
                                                         "/v3/api-docs/**", "/swagger-ui/**", "/webjars/**", "/live/active", "/member/healthcheck", "/farm/no-auth/**", "/reviews/no-auth/**",
-                                                        "/product/no-auth/**", "/seller/no-auth/**", "/ws/**", "/api/**", "/es/**");
+                                                        "/product/no-auth/**", "/seller/no-auth/**", "/ws/**", "/api/**", "/es/**", "/live/active/best");
 
     private final AntPathMatcher antPathMatcher = new AntPathMatcher();
 

--- a/backend/live/src/main/java/org/samtuap/inong/domain/live/api/LiveController.java
+++ b/backend/live/src/main/java/org/samtuap/inong/domain/live/api/LiveController.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.samtuap.inong.domain.live.dto.FavoritesLiveListResponse;
 import org.samtuap.inong.domain.live.service.LiveService;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
@@ -17,7 +18,9 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.http.ResponseEntity;
 import org.samtuap.inong.domain.live.dto.ActiveLiveListGetResponse;
 
+import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RequestMapping("/live")
 @RequiredArgsConstructor
@@ -45,5 +48,23 @@ public class LiveController {
     public ResponseEntity<Integer> getParticipantCount(@PathVariable("sessionId") String sessionId) {
         int count = liveService.getParticipantCount(sessionId);
         return ResponseEntity.ok(count);
+    }
+
+    /**
+     * main page => 라이브 목록 시청자 순 best5
+     */
+    @GetMapping("/active/best")
+    public ResponseEntity<Page<ActiveLiveListGetResponse>> getBestLive(@PageableDefault(size = 5) Pageable pageable) {
+        Page<ActiveLiveListGetResponse> response = liveService.getActiveLiveList(pageable);
+
+        List<ActiveLiveListGetResponse> sortedList = response.stream()
+                .sorted(Comparator.comparing(ActiveLiveListGetResponse::participantCount).reversed())
+                .collect(Collectors.toList());
+
+        int start = (int) pageable.getOffset();
+        int end = Math.min((start + pageable.getPageSize()), sortedList.size());
+        Page<ActiveLiveListGetResponse> sortedPage = new PageImpl<>(sortedList.subList(start, end), pageable, sortedList.size());
+
+        return new ResponseEntity<>(sortedPage, HttpStatus.OK);
     }
 }


### PR DESCRIPTION
## 📌 PR 타입
<!-- [x] 이렇게하면 체크돼요 -->
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 리팩토링
- [ ] docs 작업


## 📄 작업 내용
<!-- ex) 구글 소셜 로그인 기능추가, 프로젝트 모집글 쓰기 API 작성 -->
- 메인 페이지 > 라이브 목록 시청순 best5 출력

## 📷 결과 화면
<!-- 포스트맨 실행결과를 캡처해주세요 -->
![image - 2024-10-20T020553 017](https://github.com/user-attachments/assets/76a060c6-2505-48e6-bc1b-6225d259f18e)
현재 진행 중인 라이브 목록 2개 모두 방송자만 들어가있음 = 1명 
![image - 2024-10-20T020554 860](https://github.com/user-attachments/assets/a231aa58-2583-4278-8a54-64ff0ebb20d8)
시청자 한 명이 귤귤팜 농장 라이브를 시청함 > participantCount=2가 되면서 가장 상단으로 정렬됨 ! 


## ✔️ 기타 사항
<!-- 리뷰 받고 싶은 포인트를 적어주세요! -->

## 🌳 작업 브랜치
<!--ex)  feat/IS-1  -->
closed #288 