### PR TITLE
feat: 알림 조회, 알림 읽음처리 API 구현

### DIFF
--- a/backend/member/src/main/java/org/samtuap/inong/domain/notification/api/NotificationController.java
+++ b/backend/member/src/main/java/org/samtuap/inong/domain/notification/api/NotificationController.java
@@ -1,0 +1,29 @@
+package org.samtuap.inong.domain.notification.api;
+
+import lombok.RequiredArgsConstructor;
+import org.samtuap.inong.domain.notification.dto.NotificationGetResponse;
+import org.samtuap.inong.domain.notification.entity.Notification;
+import org.samtuap.inong.domain.notification.service.NotificationService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RequestMapping("/notification")
+@RequiredArgsConstructor
+@RestController
+public class NotificationController {
+    private final NotificationService notificationService;
+
+    @GetMapping
+    public ResponseEntity<Page<NotificationGetResponse>> getNotification(Pageable pageable, @RequestParam(value = "unread", required = false) boolean unread, @RequestHeader("myId") Long memberId) {
+        Page<NotificationGetResponse> notifications = notificationService.getNotifications(pageable, unread, memberId);
+        return ResponseEntity.ok(notifications);
+    }
+
+    @PostMapping("/read")
+    public void readNotifications(@RequestHeader("myId") Long memberId) {
+        notificationService.readNotifications(memberId);
+    }
+
+}

--- a/backend/member/src/main/java/org/samtuap/inong/domain/notification/dto/NotificationGetResponse.java
+++ b/backend/member/src/main/java/org/samtuap/inong/domain/notification/dto/NotificationGetResponse.java
@@ -1,0 +1,21 @@
+package org.samtuap.inong.domain.notification.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import org.samtuap.inong.domain.notification.entity.Notification;
+
+import java.util.List;
+
+@Builder
+public record NotificationGetResponse(String title,
+                                      String content,
+                                      boolean isRead) {
+
+    public static NotificationGetResponse fromEntity(Notification notification) {
+        return NotificationGetResponse.builder()
+                .title(notification.getTitle())
+                .content(notification.getContent())
+                .isRead(notification.isRead())
+                .build();
+    }
+}

--- a/backend/member/src/main/java/org/samtuap/inong/domain/notification/dto/NotificationIssueRequest.java
+++ b/backend/member/src/main/java/org/samtuap/inong/domain/notification/dto/NotificationIssueRequest.java
@@ -2,6 +2,8 @@ package org.samtuap.inong.domain.notification.dto;
 
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
+import org.samtuap.inong.domain.member.entity.Member;
+import org.samtuap.inong.domain.notification.entity.Notification;
 
 import java.util.List;
 
@@ -9,4 +11,13 @@ import java.util.List;
 public record NotificationIssueRequest(@NotNull String title,
                                        @NotNull String content,
                                        @NotNull List<Long> targets) {
+
+    public static Notification of(String title, String content, Member member) {
+        return Notification.builder()
+                .title(title)
+                .content(content)
+                .isRead(false)
+                .member(member)
+                .build();
+    }
 }

--- a/backend/member/src/main/java/org/samtuap/inong/domain/notification/entity/Notification.java
+++ b/backend/member/src/main/java/org/samtuap/inong/domain/notification/entity/Notification.java
@@ -1,11 +1,19 @@
 package org.samtuap.inong.domain.notification.entity;
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 import org.samtuap.inong.domain.common.BaseEntity;
 import org.samtuap.inong.domain.member.entity.Member;
 
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Entity
 @SQLDelete(sql = "UPDATE notification SET deleted_at = now() WHERE id = ?")
 @SQLRestriction("deleted_at is NULL")
@@ -14,9 +22,16 @@ public class Notification extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    private String title;
     private String content;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    private boolean isRead;
+
+    public void updateIsRead(boolean isRead) {
+        this.isRead = isRead;
+    }
 }

--- a/backend/member/src/main/java/org/samtuap/inong/domain/notification/repository/NotificationRepository.java
+++ b/backend/member/src/main/java/org/samtuap/inong/domain/notification/repository/NotificationRepository.java
@@ -1,7 +1,19 @@
 package org.samtuap.inong.domain.notification.repository;
 
 import org.samtuap.inong.domain.favorites.entity.Favorites;
+import org.samtuap.inong.domain.member.entity.Member;
+import org.samtuap.inong.domain.notification.entity.Notification;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface NotificationRepository extends JpaRepository<Favorites, Long> {
+import java.util.List;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    Page<Notification> findAllByMemberId(Pageable pageable, Long memberId);
+
+    Page<Notification> findAllByMemberIdAndIsRead(Pageable pageable, Long memberId, boolean isRead);
+
+    List<Notification> findAllByMemberIdAndIsRead(Long memberId, boolean isRead);
 }

--- a/backend/member/src/main/java/org/samtuap/inong/domain/notification/service/NotificationService.java
+++ b/backend/member/src/main/java/org/samtuap/inong/domain/notification/service/NotificationService.java
@@ -1,0 +1,34 @@
+package org.samtuap.inong.domain.notification.service;
+
+import lombok.RequiredArgsConstructor;
+import org.samtuap.inong.domain.notification.dto.NotificationGetResponse;
+import org.samtuap.inong.domain.notification.entity.Notification;
+import org.samtuap.inong.domain.notification.repository.NotificationRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class NotificationService {
+    private final NotificationRepository notificationRepository;
+
+    public Page<NotificationGetResponse> getNotifications(Pageable pageable, boolean unread, Long memberId) {
+        if(unread) {
+            return notificationRepository.findAllByMemberIdAndIsRead(pageable, memberId, false).map(NotificationGetResponse::fromEntity);
+        } else {
+            return notificationRepository.findAllByMemberId(pageable, memberId).map(NotificationGetResponse::fromEntity);
+        }
+    }
+
+    @Transactional
+    public void readNotifications(Long memberId) {
+        List<Notification> notifications = notificationRepository.findAllByMemberIdAndIsRead(memberId, false);
+        for (Notification notification : notifications) {
+            notification.updateIsRead(true);
+        }
+    }
+}


### PR DESCRIPTION
## 📌 PR 타입
<!-- [x] 이렇게하면 체크돼요 -->
- [x] 기능 추가
- [x] 기능 수정
- [ ] 리팩토링
- [ ] docs 작업


## 📄 작업 내용
<!-- ex) 구글 소셜 로그인 기능추가, 프로젝트 모집글 쓰기 API 작성 -->
- 멤버가 받은 알림을 조회할 수 있는 API (`unread`가 `true`일때 읽지 않은 알림만 표시)
- 읽음처리 API

## 📷 결과 화면
<!-- 포스트맨 실행결과를 캡처해주세요 -->
<img width="1064" alt="스크린샷 2024-10-21 오후 3 30 32" src="https://github.com/user-attachments/assets/fbc9aa06-78b1-4cf5-ac9b-269714d9cf13">
<img width="1062" alt="스크린샷 2024-10-21 오후 3 33 26" src="https://github.com/user-attachments/assets/dbabdb9c-ce7b-4729-94c1-c6a61421f257">
<img width="1068" alt="스크린샷 2024-10-21 오후 3 33 42" src="https://github.com/user-attachments/assets/908039f5-12a9-4fb5-80d6-1e4191fe0fbf">


## ✔️ 기타 사항
<!-- 리뷰 받고 싶은 포인트를 적어주세요! -->

## 🌳 작업 브랜치
<!--ex)  feat/IS-1  -->
closed #295 