### PR TITLE
feat: 오류 처리 및 결제 시 할인액 추가 처리

### DIFF
--- a/backend/order/src/main/java/org/samtuap/inong/common/client/ProductFeign.java
+++ b/backend/order/src/main/java/org/samtuap/inong/common/client/ProductFeign.java
@@ -15,6 +15,10 @@ public interface ProductFeign {
 
     @GetMapping(value = "/product/info/{id}")
     PackageProductResponse getPackageProduct(@PathVariable("id") Long packageProductId);
+
+    @GetMapping(value = "/product/info/contain-deleted/{id}")
+    PackageProductResponse getPackageProductContainDeleted(@PathVariable("id") Long packageProductId);
+
     @PostMapping(value = "/product/info")
     List<PackageProductResponse> getPackageProductList(@RequestBody List<Long> ids);
 

--- a/backend/order/src/main/java/org/samtuap/inong/domain/delivery/dto/PackageProductResponse.java
+++ b/backend/order/src/main/java/org/samtuap/inong/domain/delivery/dto/PackageProductResponse.java
@@ -9,6 +9,9 @@ public record PackageProductResponse(
         Long farmId,
         String farmName,
         Long price,
-        Integer delivery_cycle) {
+        Integer delivery_cycle,
+        Long discountId,
+        Integer discount,
+        boolean discountActive) {
 
 }

--- a/backend/order/src/main/java/org/samtuap/inong/domain/delivery/service/DeliveryService.java
+++ b/backend/order/src/main/java/org/samtuap/inong/domain/delivery/service/DeliveryService.java
@@ -102,7 +102,7 @@ public class DeliveryService {
 
         return deliveries.map(delivery -> {
             MemberDetailResponse member = memberFeign.getMemberById(delivery.getOrdering().getMemberId());
-            PackageProductResponse packageProduct = productFeign.getPackageProduct(delivery.getOrdering().getPackageId());
+            PackageProductResponse packageProduct = productFeign.getPackageProductContainDeleted(delivery.getOrdering().getPackageId());
 
             return DeliveryCompletedListResponse.from(delivery, member.name(), packageProduct.packageName());
         });
@@ -114,7 +114,7 @@ public class DeliveryService {
         Page<Delivery> deliveries = deliveryRepository.findByOrderingInAndDeliveryStatusIn(orderlist, statuses, pageable);
 
         return deliveries.map(delivery -> {
-            PackageProductResponse product = productFeign.getPackageProduct(delivery.getOrdering().getPackageId());
+            PackageProductResponse product = productFeign.getPackageProductContainDeleted(delivery.getOrdering().getPackageId());
             return DeliveryListResponse.fromEntity(product, delivery);
         });
     }

--- a/backend/order/src/main/java/org/samtuap/inong/domain/delivery/service/DeliveryService.java
+++ b/backend/order/src/main/java/org/samtuap/inong/domain/delivery/service/DeliveryService.java
@@ -51,7 +51,7 @@ public class DeliveryService {
 
         return deliveries.map(delivery -> {
             MemberDetailResponse member = memberFeign.getMemberById(delivery.getOrdering().getMemberId());
-            PackageProductResponse packageProduct = productFeign.getPackageProduct(delivery.getOrdering().getPackageId());
+            PackageProductResponse packageProduct = productFeign.getPackageProductContainDeleted(delivery.getOrdering().getPackageId());
             return DeliveryUpComingListResponse.from(delivery, member.name(), packageProduct.packageName());
         });
     }

--- a/backend/order/src/main/java/org/samtuap/inong/domain/order/dto/DiscountDetailResponse.java
+++ b/backend/order/src/main/java/org/samtuap/inong/domain/order/dto/DiscountDetailResponse.java
@@ -1,0 +1,15 @@
+package org.samtuap.inong.domain.order.dto;
+
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+@Builder
+public record DiscountDetailResponse(
+        Long id,
+        Integer discount, // 할인 금액
+        LocalDate startAt,
+        LocalDate endAt,
+        boolean discountActive
+) {
+}

--- a/backend/product/src/main/java/org/samtuap/inong/domain/discount/service/DiscountService.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/discount/service/DiscountService.java
@@ -106,13 +106,6 @@ public class DiscountService {
             cacheManager.getCache("PackageDetail").evict(productId);
         }
 
-//        // 변경된 할인이 적용된 상품의 캐시 삭제 처리
-//        List<PackageProduct> discountProducts = packageProductRepository.findAllByDiscountId(discountId);
-//        if(!discountProducts.isEmpty()){
-//            for (PackageProduct product : discountProducts) {
-//                cacheManager.getCache("PackageDetail").evict(product.getId());
-//            }
-//        }
         discountRepository.save(existingDiscount);
     }
 

--- a/backend/product/src/main/java/org/samtuap/inong/domain/product/api/PackageProductController.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/product/api/PackageProductController.java
@@ -45,6 +45,12 @@ public class PackageProductController {
         return packageProductService.getProductInfo(packageProductId);
     }
 
+    //  Feign 요청용 메서드(삭제 처리된 상품까
+    @GetMapping("/info/contain-deleted/{id}")
+    public PackageProductResponse getPackageProductContainDeleted(@PathVariable("id") Long packageProductId) {
+        return packageProductService.getProductInfoContainDeleted(packageProductId);
+    }
+
     @PostMapping("/create")
     public ResponseEntity<PackageProductCreateResponse> createProduct(@RequestHeader Long sellerId,
                                                                       @RequestBody PackageProductCreateRequest request) {

--- a/backend/product/src/main/java/org/samtuap/inong/domain/product/repository/PackageProductRepository.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/product/repository/PackageProductRepository.java
@@ -26,6 +26,9 @@ public interface PackageProductRepository extends JpaRepository<PackageProduct, 
         return findById(packageId).orElseThrow(()->new BaseCustomException(PRODUCT_NOT_FOUND));
     }
 
+    @Query(value = "SELECT p.* FROM package_product AS p WHERE p.id = :id", nativeQuery = true)
+    PackageProduct findByIdIncludeDeleted(@Param("id") Long packageId);
+
     boolean existsByFarmIdAndDeletedAtIsNull(Long farmId);
 
     @Query(value = "SELECT p.* FROM package_product AS p WHERE p.id IN :ids", nativeQuery = true)

--- a/backend/product/src/main/java/org/samtuap/inong/domain/product/service/PackageProductService.java
+++ b/backend/product/src/main/java/org/samtuap/inong/domain/product/service/PackageProductService.java
@@ -102,6 +102,19 @@ public class PackageProductService {
         }
     }
 
+    @Cacheable(value = "PackageDetail", key = "#packageProductId", cacheManager = "contentCacheManager")
+    public PackageProductResponse getProductInfoContainDeleted(Long packageProductId) {
+        PackageProduct packageProduct = packageProductRepository.findByIdIncludeDeleted(packageProductId);
+        List<PackageProductImage> packageProductImage = packageProductImageRepository.findAllByPackageProduct(packageProduct);
+
+        if (packageProduct.getDiscountId() != null) {
+            Discount discount = discountRepository.findByIdThrow(packageProduct.getDiscountId());
+            return PackageProductResponse.fromEntity(packageProduct, packageProductImage, discount.getDiscount(), discount.isDiscountActive());
+        } else {
+            return PackageProductResponse.fromEntity(packageProduct, packageProductImage, null, false);
+        }
+    }
+
     public PackageProductResponse getProductInfoNoCache(Long packageProductId) {
         PackageProduct packageProduct = packageProductRepository.findByIdOrThrow(packageProductId);
         List<PackageProductImage> packageProductImage = packageProductImageRepository.findAllByPackageProduct(packageProduct);


### PR DESCRIPTION
## 📌 PR 타입
<!-- [x] 이렇게하면 체크돼요 -->
- [x] 기능 추가
- [x] 기능 수정
- [ ] 리팩토링
- [ ] docs 작업


## 📄 작업 내용
<!-- ex) 구글 소셜 로그인 기능추가, 프로젝트 모집글 쓰기 API 작성 -->
구독중인 상품을 삭제 시 구매자 마이 페이지 결제 내역 서버 에러 해결

위시리스트 상품 삭제시 구매자 마이 페이지 위시리스트 서버 에러 해결

농장 상품 리스트 위시리스트 적용 

영수증 화면 쿠폰, 세일 값 결제금액에 합산 

결제 페이지에선 주문요약에 합계가 제대로 잡히지만, 결제 시 할인 금액 차감

서버에서 주문 결과에 discount적용

사장님 내 농장 관리 페이지 → 주문 및 배송 관리 서버에러 해결


## 📷 결과 화면
<!-- 포스트맨 실행결과를 캡처해주세요 -->
상품 삭제해도 결제 내역 페이지 보임
![image](https://github.com/user-attachments/assets/f815a934-79b2-4da5-aa03-9304f7edc3b7)

영수증에 할인+쿠폰 금액 합쳐서 할인금액에 출력, 결제금액 정상적으로 작동
![image](https://github.com/user-attachments/assets/234e55e2-650b-4aa3-83c9-23c0927691fa)

결제 시 원금에서 쿠폰액만 차감되었는데 할인액도 추가 차감
![image](https://github.com/user-attachments/assets/d801048d-2c66-4af8-8038-2b82066d9ce9)

상품 삭제해도 주문 및 배송처리 에러 안남
![image](https://github.com/user-attachments/assets/b473f353-2413-4d56-9cf7-76bb598febab)

## ✔️ 기타 사항
<!-- 리뷰 받고 싶은 포인트를 적어주세요! -->

## 🌳 작업 브랜치
<!--ex)  feat/IS-1  -->
closed #336